### PR TITLE
fix: Have the display show the current time even though some settings are undefined

### DIFF
--- a/edge-apps/clock/index.html
+++ b/edge-apps/clock/index.html
@@ -15,7 +15,7 @@
           tag_manager_id: tagManagerId,
         } = screenly.settings;
 
-        if (disableAnalytics !== 'true') {
+        if (disableAnalytics !== undefined && disableAnalytics !== 'true') {
             (function(w, d, s, l, i) {
                 w[l] = w[l] || [];
                 w[l].push({

--- a/edge-apps/clock/static/js/main.js
+++ b/edge-apps/clock/static/js/main.js
@@ -24,9 +24,7 @@ function initApp () {
   const initDateTime = () => {
     clearTimeout(clockTimer)
 
-    const timezone = (settings?.override_timezone != '')
-      ? settings.override_timezone
-      : tzlookup(latitude, longitude)
+    const timezone = settings?.override_timezone || tzlookup(latitude, longitude)
     const momentObject = moment().tz(timezone)
 
     document.querySelector('#date').innerText = momentObject.format('DD MMMM, YYYY')


### PR DESCRIPTION
### Overview

The display (screen) is not able to display the current time, even if the clock app was uploaded successfully.

### Screenshots

![image](https://github.com/Screenly/Playground/assets/10234135/180a1c98-1c6d-4f18-a67e-ebdbc33c4425)