### PR TITLE
Applies hotfixes to RSS reader app

### DIFF
--- a/edge-apps/rss-reader/screenly.yml
+++ b/edge-apps/rss-reader/screenly.yml
@@ -8,7 +8,7 @@ homepage_url: ''
 settings:
   bypass_cors:
     type: string
-    default_value: 'false'
+    default_value: 'true'
     title: bypass_cors
     optional: true
     help_text: |


### PR DESCRIPTION
### What this PR does

- [x] Changes the default value of bypass_cors from `false` to `true`. This is because the default value set for the `rss_url` is the one from BBC.
- [x] Ensures that the app is tested against various RSS feed sources

### RSS URLs I've tested so far

| URL                                                 | Requires CORS | bypass_cors |
| --------------------------------------------------- | ------------- | ----------- |
| http://feeds.bbci.co.uk/news/rss.xml                | Yes           | true        |
| https://lifehacker.com/rss                          | Yes           | true        |
| https://www.reddit.com/.rss                         | Yes           | true        |
| https://rss.nytimes.com/services/xml/rss/nyt/US.xml | No            | false       |
| http://rss.sciam.com/sciam/60secsciencepodcast      | Yes           | true        |

Furthermore, you can see a curated list of RSS feeds here &mdash; https://github.com/plenaryapp/awesome-rss-feeds.