### PR TITLE
Fix: deploy workflow for Clock/Weather and RSS reader Edge Apps

### DIFF
--- a/.github/workflows/deploy-clock-app.yml
+++ b/.github/workflows/deploy-clock-app.yml
@@ -13,7 +13,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      APP_ID: '01H8PFD70PYNZ440QJ42SSQXF6'
+      APP_ID: ''
       APP_PATH: 'edge-apps/clock'
 
     steps:
@@ -27,23 +27,9 @@ jobs:
             # yamllint disable-line rule:line-length
           cli_commands: edge-app upload --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
 
-      - name: Get Revisions
-        id: get_revisions
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN }}
-            # yamllint disable-line rule:line-length
-          cli_commands: edge-app version list --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }} --json
-
-      - name: Latest Revision
-        # Using `jq` to extract the latest revision
-        id: latest_revision
-          # yamllint disable-line rule:line-length
-        run: echo "revision=$(echo ${{ steps.get_revisions.stdout.value }} | jq '.[-1:] | .[].revision')" >> "$GITHUB_OUTPUT"
-
       - name: Promote Edge App
         uses: screenly/cli@master
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN }}
             # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --revision=${{ steps.latest_revision.outputs.revision }} --channel=candidate --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app version promote --latest --channel=candidate --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}

--- a/.github/workflows/deploy-rss-reader.yml
+++ b/.github/workflows/deploy-rss-reader.yml
@@ -13,7 +13,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      APP_ID: '01H8PFEZDA5THTPQ7Y19Z9KDQ0'
+      APP_ID: ''
       APP_PATH: 'edge-apps/rss-reader'
 
     steps:
@@ -27,23 +27,9 @@ jobs:
             # yamllint disable-line rule:line-length
           cli_commands: edge-app upload --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
 
-      - name: Get Revisions
-        id: get_revisions
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN }}
-            # yamllint disable-line rule:line-length
-          cli_commands: edge-app version list --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }} --json
-
-      - name: Latest Revision
-        # Using `jq` to extract the latest revision
-        id: latest_revision
-          # yamllint disable-line rule:line-length
-        run: echo "revision=$(echo ${{ steps.get_revisions.stdout.value }} | jq '.[-1:] | .[].revision')" >> "$GITHUB_OUTPUT"
-
       - name: Promote Edge App
         uses: screenly/cli@master
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN }}
             # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --revision=${{ steps.latest_revision.outputs.revision }} --channel=candidate --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app version promote --latest --channel=candidate --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}

--- a/.github/workflows/deploy-weather-app.yml
+++ b/.github/workflows/deploy-weather-app.yml
@@ -13,7 +13,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      APP_ID: '01H8PFEJC8QRQ8DJAWV84NT4HH'
+      APP_ID: ''
       APP_PATH: 'edge-apps/weather'
 
     steps:
@@ -27,23 +27,9 @@ jobs:
             # yamllint disable-line rule:line-length
           cli_commands: edge-app upload --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
 
-      - name: Get Revisions
-        id: get_revisions
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN }}
-            # yamllint disable-line rule:line-length
-          cli_commands: edge-app version list --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }} --json
-
-      - name: Latest Revision
-        # Using `jq` to extract the latest revision
-        id: latest_revision
-          # yamllint disable-line rule:line-length
-        run: echo "revision=$(echo ${{ steps.get_revisions.stdout.value }} | jq '.[-1:] | .[].revision')" >> "$GITHUB_OUTPUT"
-
       - name: Promote Edge App
         uses: screenly/cli@master
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN }}
             # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --revision=${{ steps.latest_revision.outputs.revision }} --channel=candidate --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app version promote --latest --channel=candidate --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}


### PR DESCRIPTION
Edits:
- Fix: deploy workflow for Clock/Weather and RSS reader Edge Apps

Proofs:
- https://github.com/rusko124/playground/actions/runs/7471539798/job/20331998389
- https://github.com/rusko124/playground/actions/runs/7471539795/job/20331998403
- https://github.com/rusko124/playground/actions/runs/7471539793/job/20331998393

Notes:
- Need to set Edge App IDs