### PR TITLE
New: override_coordinates setting for Weather Edge App

### DIFF
--- a/edge-apps/weather/screenly.yml
+++ b/edge-apps/weather/screenly.yml
@@ -22,3 +22,11 @@ settings:
     title: tag_manager_id
     optional: true
     help_text: Specify a Google Tag Manager ID
+  override_coordinates:
+    type: string
+    default_value: ''
+    title: override_coordinates
+    optional: true
+    help_text: |
+      Specify a comma-separated pair of coordinates (e.g., 37.8267,-122.4233).
+      If not specified, the app will attempt to use the device's coordinates.

--- a/edge-apps/weather/static/js/main.js
+++ b/edge-apps/weather/static/js/main.js
@@ -312,7 +312,7 @@ function getWeatherData () {
     isLoading: true,
     init: async function () {
       if (screenly.settings.override_coordinates) {
-        [this.lat, this.lng] = screenly.settings.override_coordinates.split(",")
+        [this.lat, this.lng] = screenly.settings.override_coordinates.split(',')
       }
 
       if (!this.lat || !this.lng) {

--- a/edge-apps/weather/static/js/main.js
+++ b/edge-apps/weather/static/js/main.js
@@ -311,7 +311,14 @@ function getWeatherData () {
     firstFetchComplete: false,
     isLoading: true,
     init: async function () {
-      [this.lat, this.lng] = screenly.metadata?.coordinates
+      if (screenly.settings.override_coordinates) {
+        [this.lat, this.lng] = screenly.settings.override_coordinates.split(",")
+      }
+
+      if (!this.lat || !this.lng) {
+        [this.lat, this.lng] = screenly.metadata?.coordinates
+      }
+
       this.apiKey = screenly.settings.openweathermap_api_key
 
       await refreshWeather(this)


### PR DESCRIPTION
Edits:
- Added `override_coordinates` setting that allows to override of screen metadata coordinates.