### PR TITLE
Adds wait signal to Power BI Edge App

### DIFF
--- a/edge-apps/powerbi/index.html
+++ b/edge-apps/powerbi/index.html
@@ -5,7 +5,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Screenly Power BI Edge App</title>
-    <!-- REMOVE ME - FORCED VERSION BUMP INVOKER -->
 
     <style>
       body {
@@ -55,6 +54,9 @@
             }
 
             var report = powerbi.embed(embedContainer, embedConfiguration);
+            report.on("rendered", function () {
+              screenly.signalReadyForRendering();
+            });
         }
 
     </script>

--- a/edge-apps/powerbi/screenly.yml
+++ b/edge-apps/powerbi/screenly.yml
@@ -57,3 +57,9 @@ settings:
     title: Power BI report page name
     optional: true
     help_text: Display a specific page (i.e. tab name) within a given Power BI report to display
+  screenly_render_notification:
+    type: string
+    default_value: "1"
+    title: "Requires ready for rendering"
+    help_text: "Special setting to indicate that application needs to call screenly.signalReadyForRendering before being shown on the screen."
+    optional: true

--- a/edge-apps/weather/index.html
+++ b/edge-apps/weather/index.html
@@ -5,7 +5,6 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link rel="stylesheet" href="static/styles/main.css" />
         <link rel="stylesheet" href="static/styles/background.css" />
-        <!-- Bump force 2 -->
     </head>
     <body x-data="weather" :class="bgClass">
         <script src="screenly.js?version=1"></script>

--- a/edge-apps/weather/index.html
+++ b/edge-apps/weather/index.html
@@ -5,6 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link rel="stylesheet" href="static/styles/main.css" />
         <link rel="stylesheet" href="static/styles/background.css" />
+        <!-- Bump force 2 -->
     </head>
     <body x-data="weather" :class="bgClass">
         <script src="screenly.js?version=1"></script>

--- a/edge-apps/weather/screenly.yml
+++ b/edge-apps/weather/screenly.yml
@@ -14,6 +14,7 @@ settings:
     type: secret
     title: Openweathermap API Key
     optional: false
+    is_global: true
     help_text: |
       Specify an API key so that you'll have access to all the necessary weather data.
   tag_manager_id:


### PR DESCRIPTION
Introduced in Screenly Client version 3.6.1, we can now instruct the device to wait for a wait signal before showing the content on screen. This is the first adoption of this to ensure Power BI loads snappier.