### PR TITLE
Improves usability of Edge App for reports

### DIFF
--- a/.github/linters/.yamllint.yml
+++ b/.github/linters/.yamllint.yml
@@ -1,3 +1,4 @@
+---
 extends: default
 
 rules:

--- a/.github/linters/.yamllint.yml
+++ b/.github/linters/.yamllint.yml
@@ -1,0 +1,8 @@
+extends: default
+
+rules:
+  # 80 chars should be enough, but don't fail if a line is longer
+  line-length:
+    max: 80
+    level: warning
+

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -48,7 +48,8 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter@v4
+        uses: github/super-linter@v5
         env:
           VALIDATE_ALL_CODEBASE: false
+          VALIDATE_HTML: false
           DEFAULT_BRANCH: master

--- a/edge-apps/iframe/screenly.yml
+++ b/edge-apps/iframe/screenly.yml
@@ -1,5 +1,4 @@
 ---
-user_version: v1.0.0
 author: Screenly, Inc.
 description: Screenly iframe Edge App
 entrypoint: index.html
@@ -8,4 +7,9 @@ settings:
     type: string
     title: iframe
     optional: true
-    help_text: iframe URL
+    help_text: |
+      Provide an iframe URL to be embedded.
+
+      This can be provided in either the full format (`<iframe src="https://foobar.com" style="height:200px;width:300px;" title="Iframe Example"></iframe>`), or just the `src` (e.g. `https://foobar.com`).
+
+      The Edge App will automatically strip out style (e.g. height, width etc) to optimize for the best full-screen experience.

--- a/edge-apps/powerbi/.htmlhintrc
+++ b/edge-apps/powerbi/.htmlhintrc
@@ -1,0 +1,3 @@
+{
+  "id-class-value": false
+}

--- a/edge-apps/powerbi/index.html
+++ b/edge-apps/powerbi/index.html
@@ -5,7 +5,7 @@
     It's not possible to disable specific rules in htmllint, and this HTML doesn't pass the 'id-class-value' test,
     but changing these classes breaks the JavaScript. Thus we're just going to ease off the linting.
 -->
-<!--htmlhint tag-pair,id-class-value -->
+<!--htmlhint tag-pair -->
 
 <head>
     <meta charset="UTF-8">

--- a/edge-apps/powerbi/index.html
+++ b/edge-apps/powerbi/index.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
+<!--htmlhint tag-pair -->
 <html lang="en">
-
 <!--
     It's not possible to disable specific rules in htmllint, and this HTML doesn't pass the 'id-class-value' test,
     but changing these classes breaks the JavaScript. Thus we're just going to ease off the linting.
 -->
-<!--htmlhint tag-pair -->
 
 <head>
     <meta charset="UTF-8">

--- a/edge-apps/powerbi/index.html
+++ b/edge-apps/powerbi/index.html
@@ -36,7 +36,7 @@
 
             // Configuration settings for embedding
             var embedConfiguration = {
-                type: screenly.settings.power_bi_resource_type,
+                type: screenly.settings.power_bi_resource_type.toLowerCase(),
                 tokenType: models.TokenType.Embed,
                 accessToken: screenly.settings.power_bi_access_token,
                 embedUrl: screenly.settings.power_bi_embed_url,

--- a/edge-apps/powerbi/index.html
+++ b/edge-apps/powerbi/index.html
@@ -1,11 +1,5 @@
 <!DOCTYPE html>
-<!--htmlhint tag-pair -->
 <html lang="en">
-<!--
-    It's not possible to disable specific rules in htmllint, and this HTML doesn't pass the 'id-class-value' test,
-    but changing these classes breaks the JavaScript. Thus we're just going to ease off the linting.
--->
-
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/edge-apps/powerbi/index.html
+++ b/edge-apps/powerbi/index.html
@@ -1,6 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
 
+<!--
+    It's not possible to disable specific rules in htmllint, and this HTML doesn't pass the 'id-class-value' test,
+    but changing these classes breaks the JavaScript. Thus we're just going to ease off the linting.
+-->
+<!--htmlhint tag-pair,id-class-value -->
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/edge-apps/powerbi/screenly.yml
+++ b/edge-apps/powerbi/screenly.yml
@@ -9,54 +9,55 @@ settings:
     default_value:
     title: Azure AD Client ID
     optional: false
-    help_text: The Oauth 2.0 Client ID for Azure AD
+    help_text: The Oauth 2.0 Client ID for Azure AD.
   azure_ad_client_secret:
     type: secret
     title: Azure AD Client Secret
     optional: false
-    help_text: The Oauth 2.0 Client Secret for Azure AD
+    help_text: The Oauth 2.0 Client Secret for Azure AD.
   azure_ad_resource:
     type: string
     default_value: https://login.microsoftonline.com
     title: Oauth 2.0 Resource
     optional: false
-    help_text: The Oauth 2.0 Resource for Azure AD
+    help_text: The Oauth 2.0 Resource for Azure AD.
   azure_ad_scope:
     type: string
     default_value: https://analysis.windows.net/powerbi/api
     title: Oauth 2.0 Scope
     optional: false
-    help_text: The Oauth 2.0 Scope for Azure AD
+    help_text: The Oauth 2.0 Scope for Azure AD.
   azure_ad_tenant_id:
     type: string
     default_value:
     title: Microsoft Tenant ID
     optional: false
-    help_text: The Microsoft Tenant ID
+    help_text: The Microsoft Tenant ID.
   power_bi_group_id:
     type: string
     default_value:
     title: Power Group ID
     optional: false
-    help_text: The Group ID, also known as Workspace ID
+    help_text: The Group ID, also known as Workspace ID.
   power_bi_resource_id:
     type: string
     default_value:
     title: Power BI Dashboard or Report ID
     optional: false
-    help_text: The Dashboard or Report ID
+    help_text: The Dashboard or Report ID.
   power_bi_resource_type:
     type: string
     default_value:
     title: Power BI resource type, meaning report or dashboard
     optional: false
-    help_text: The resource type, meaning report or dashboard
+    help_text: The resource type, meaning report or dashboard.
   power_bi_page_name:
     type: string
     default_value:
     title: Power BI report page name
     optional: true
-    help_text: Display a specific page (i.e. tab name) within a given Power BI report to display
+    help_text: |
+      Display a specific page (i.e. tab name) within a given Power BI report to display. Note that this is NOT the name shown the report. You can the value of this in the URL when you are viewing the page, and this starts with `ReportSection50033...a22c`.
   screenly_render_notification:
     type: string
     default_value: "1"

--- a/edge-apps/powerbi/screenly.yml
+++ b/edge-apps/powerbi/screenly.yml
@@ -1,6 +1,7 @@
 ---
 author: Screenly, Inc.
-description: Displays Power BI dashboards and reports with big focus on security.
+description: |
+  Displays Power BI dashboards and reports with big focus on security.
 icon: 'https://playground.srly.io/edge-apps/powerbi/static/images/icon.svg'
 entrypoint: index.html
 settings:
@@ -57,10 +58,14 @@ settings:
     title: Power BI report page name
     optional: true
     help_text: |
-      Display a specific page (i.e. tab name) within a given Power BI report to display. Note that this is NOT the name shown the report. You can the value of this in the URL when you are viewing the page, and this starts with `ReportSection50033...a22c`.
+      Display a specific page (i.e. tab name) within a given Power BI report to display.
+      Note that this is NOT the name shown the report.
+      You can the value of this in the URL when you are viewing the page, and this starts with `ReportSection50033...a22c`.
   screenly_render_notification:
     type: string
     default_value: "1"
     title: "Requires ready for rendering"
-    help_text: "Special setting to indicate that application needs to call screenly.signalReadyForRendering before being shown on the screen."
+    help_text: |
+      "Special setting to indicate that application needs to call
+      screenly.signalReadyForRendering before being shown on the screen."
     optional: true

--- a/edge-apps/powerbi/screenly.yml
+++ b/edge-apps/powerbi/screenly.yml
@@ -58,14 +58,12 @@ settings:
     title: Power BI report page name
     optional: true
     help_text: |
-      Display a specific page (i.e. tab name) within a given Power BI report to display.
-      Note that this is NOT the name shown the report.
+      Display a specific page (i.e. tab name) within a given Power BI report to display. Note that this is NOT the name shown in the report.
       You can the value of this in the URL when you are viewing the page, and this starts with `ReportSection50033...a22c`.
   screenly_render_notification:
     type: string
     default_value: "1"
     title: "Requires ready for rendering"
     help_text: |
-      "Special setting to indicate that application needs to call
-      screenly.signalReadyForRendering before being shown on the screen."
+      Special setting to indicate that application needs to call screenly.signalReadyForRendering before being shown on the screen.
     optional: true


### PR DESCRIPTION
* Allows `report` to be provided as `Report` by enforcing lower case in JS
* Improves documentation for page names based on [this article](https://community.fabric.microsoft.com/t5/Developer/set-active-page-in-report-with-JavaScript-API/m-p/93716)
* (Unrelated: Tweaks helper text for iframe edge app)