### PR TITLE
Updates: use installation_id instead of app_id for promote command

### DIFF
--- a/.github/workflows/deploy-clock-app-qc.yml
+++ b/.github/workflows/deploy-clock-app-qc.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       APP_ID: '01HKT1XSC070BGNKYR7ZE689DE'
+      INSTALLATION_ID: ''
 
       APP_PATH: 'edge-apps/clock'
 
@@ -40,4 +41,4 @@ jobs:
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_AUTOMATED_QC }}
           # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --latest --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app version promote --latest --installation-id=${{ env.INSTALLATION_ID }} --path=${{ env.APP_PATH }}

--- a/.github/workflows/deploy-clock-app-qc.yml
+++ b/.github/workflows/deploy-clock-app-qc.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       APP_ID: '01HKT1XSC070BGNKYR7ZE689DE'
-      INSTALLATION_ID: ''
+      INSTALLATION_ID: '01HKT1YB1AQK79HQ5GF23F2ZAX'
 
       APP_PATH: 'edge-apps/clock'
 

--- a/.github/workflows/deploy-clock-app.yml
+++ b/.github/workflows/deploy-clock-app.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       APP_ID: '01HKT2K8GVE8P6RE36QFKPG5G1'
-      INSTALLATION_ID: ''
+      INSTALLATION_ID: '01HKT2KZKZA270VKF3Z9PDKVJS'
 
       APP_PATH: 'edge-apps/clock'
 

--- a/.github/workflows/deploy-clock-app.yml
+++ b/.github/workflows/deploy-clock-app.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       APP_ID: '01HKT2K8GVE8P6RE36QFKPG5G1'
+      INSTALLATION_ID: ''
 
       APP_PATH: 'edge-apps/clock'
 
@@ -35,4 +36,4 @@ jobs:
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
           # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --latest --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app version promote --latest --installation-id=${{ env.INSTALLATION_ID }} --path=${{ env.APP_PATH }}

--- a/.github/workflows/deploy-countdown-timer-qc.yml
+++ b/.github/workflows/deploy-countdown-timer-qc.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       APP_ID: '01HS8ZQP09W71PAMEZ65GH6SVV'
-      INSTALLATION_ID: ''
+      INSTALLATION_ID: '01HS8ZRGW789VHMJX3N2RVM794'
 
       APP_PATH: 'edge-apps/countdown-timer'
 

--- a/.github/workflows/deploy-countdown-timer-qc.yml
+++ b/.github/workflows/deploy-countdown-timer-qc.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       APP_ID: '01HS8ZQP09W71PAMEZ65GH6SVV'
+      INSTALLATION_ID: ''
 
       APP_PATH: 'edge-apps/countdown-timer'
 
@@ -40,4 +41,4 @@ jobs:
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_AUTOMATED_QC }}
           # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --latest --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app version promote --latest --installation-id=${{ env.INSTALLATION_ID }} --path=${{ env.APP_PATH }}

--- a/.github/workflows/deploy-countdown-timer.yml
+++ b/.github/workflows/deploy-countdown-timer.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       APP_ID: '01HS8ZSEPGFZDKE606PD038TTB'
-      INSTALLATION_ID: ''
+      INSTALLATION_ID: '01HS8ZT7KNB3MB8EAC2YET8DB2'
 
       APP_PATH: 'edge-apps/countdown-timer'
 

--- a/.github/workflows/deploy-countdown-timer.yml
+++ b/.github/workflows/deploy-countdown-timer.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       APP_ID: '01HS8ZSEPGFZDKE606PD038TTB'
+      INSTALLATION_ID: ''
 
       APP_PATH: 'edge-apps/countdown-timer'
 
@@ -35,4 +36,4 @@ jobs:
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
           # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --latest --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app version promote --latest --installation-id=${{ env.INSTALLATION_ID }} --path=${{ env.APP_PATH }}

--- a/.github/workflows/deploy-iframe-qc.yml
+++ b/.github/workflows/deploy-iframe-qc.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       APP_ID: '01HSGG4DJ6D2WE9GN0V7E4TSP1'
-      INSTALLATION_ID: ''
+      INSTALLATION_ID: '01HSGG5616M1JFA6Q0Z258NA4A'
 
       APP_PATH: 'edge-apps/iframe'
 

--- a/.github/workflows/deploy-iframe-qc.yml
+++ b/.github/workflows/deploy-iframe-qc.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       APP_ID: '01HSGG4DJ6D2WE9GN0V7E4TSP1'
+      INSTALLATION_ID: ''
 
       APP_PATH: 'edge-apps/iframe'
 
@@ -40,4 +41,4 @@ jobs:
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_AUTOMATED_QC }}
           # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --latest --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app version promote --latest --installation-id=${{ env.INSTALLATION_ID }} --path=${{ env.APP_PATH }}

--- a/.github/workflows/deploy-iframe.yml
+++ b/.github/workflows/deploy-iframe.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       APP_ID: '01HSGGB40HC05XK0M1WDDVEHAH'
-      INSTALLATION_ID: ''
+      INSTALLATION_ID: '01HSGGBC6HSXYFEYPN8NJ88186'
 
       APP_PATH: 'edge-apps/iframe'
 

--- a/.github/workflows/deploy-iframe.yml
+++ b/.github/workflows/deploy-iframe.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       APP_ID: '01HSGGB40HC05XK0M1WDDVEHAH'
+      INSTALLATION_ID: ''
 
       APP_PATH: 'edge-apps/iframe'
 
@@ -40,4 +41,4 @@ jobs:
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
           # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --latest --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app version promote --latest --installation-id=${{ env.INSTALLATION_ID }} --path=${{ env.APP_PATH }}

--- a/.github/workflows/deploy-power-bi-qc.yml
+++ b/.github/workflows/deploy-power-bi-qc.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       APP_ID: '01HRCAW49EW573V7JCH711SP5G'
+      INSTALLATION_ID: ''
 
       APP_PATH: 'edge-apps/powerbi'
 
@@ -40,4 +41,4 @@ jobs:
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_AUTOMATED_QC }}
           # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --latest --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app version promote --latest --installation-id=${{ env.INSTALLATION_ID }} --path=${{ env.APP_PATH }}

--- a/.github/workflows/deploy-power-bi-qc.yml
+++ b/.github/workflows/deploy-power-bi-qc.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       APP_ID: '01HRCAW49EW573V7JCH711SP5G'
-      INSTALLATION_ID: ''
+      INSTALLATION_ID: '01HRCAWQHXDAP5XZ53KZAP2SP7'
 
       APP_PATH: 'edge-apps/powerbi'
 

--- a/.github/workflows/deploy-power-bi.yml
+++ b/.github/workflows/deploy-power-bi.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       APP_ID: '01HRCB5Z5TZZFT6J37RNVQYC38'
+      INSTALLATION_ID: ''
 
       APP_PATH: 'edge-apps/powerbi'
 
@@ -40,4 +41,4 @@ jobs:
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
           # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --latest --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app version promote --latest --installation-id=${{ env.INSTALLATION_ID }} --path=${{ env.APP_PATH }}

--- a/.github/workflows/deploy-power-bi.yml
+++ b/.github/workflows/deploy-power-bi.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       APP_ID: '01HRCB5Z5TZZFT6J37RNVQYC38'
-      INSTALLATION_ID: ''
+      INSTALLATION_ID: '01HRCBDACKA1DFNK5T1GZVX67D'
 
       APP_PATH: 'edge-apps/powerbi'
 

--- a/.github/workflows/deploy-rss-reader-qc.yml
+++ b/.github/workflows/deploy-rss-reader-qc.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       APP_ID: '01HKT59B49Z343B7C2H9JVH51B'
-      INSTALLATION_ID: ''
+      INSTALLATION_ID: '01HKT5CZ14CAB58SZ8EZ1NQMMH'
       APP_PATH: 'edge-apps/rss-reader'
 
     steps:

--- a/.github/workflows/deploy-rss-reader-qc.yml
+++ b/.github/workflows/deploy-rss-reader-qc.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       APP_ID: '01HKT59B49Z343B7C2H9JVH51B'
+      INSTALLATION_ID: ''
       APP_PATH: 'edge-apps/rss-reader'
 
     steps:
@@ -45,4 +46,4 @@ jobs:
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_AUTOMATED_QC }}
           # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --latest --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app version promote --latest --installation-id=${{ env.INSTALLATION_ID }} --path=${{ env.APP_PATH }}

--- a/.github/workflows/deploy-rss-reader.yml
+++ b/.github/workflows/deploy-rss-reader.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       APP_ID: '01HKT5KJPAHVGYJSFQF80BCJYQ'
-      INSTALLATION_ID: ''
+      INSTALLATION_ID: '01HKT5QZ2H4CZ0AHFTXVQ0BQ9A'
       APP_PATH: 'edge-apps/rss-reader'
 
     steps:

--- a/.github/workflows/deploy-rss-reader.yml
+++ b/.github/workflows/deploy-rss-reader.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       APP_ID: '01HKT5KJPAHVGYJSFQF80BCJYQ'
+      INSTALLATION_ID: ''
       APP_PATH: 'edge-apps/rss-reader'
 
     steps:
@@ -40,4 +41,4 @@ jobs:
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
           # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --latest --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app version promote --latest --installation-id=${{ env.INSTALLATION_ID }} --path=${{ env.APP_PATH }}

--- a/.github/workflows/deploy-simple-message-app.yml
+++ b/.github/workflows/deploy-simple-message-app.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       APP_ID: '01HTYXDZVA532Z1GN4CX5Z7VH7'
+      INSTALLATION_ID: ''
       APP_PATH: 'edge-apps/simple-message-app'
 
     steps:
@@ -34,4 +35,4 @@ jobs:
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
           # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --latest --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app version promote --latest --installation-id=${{ env.INSTALLATION_ID }} --path=${{ env.APP_PATH }}

--- a/.github/workflows/deploy-simple-message-app.yml
+++ b/.github/workflows/deploy-simple-message-app.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       APP_ID: '01HTYXDZVA532Z1GN4CX5Z7VH7'
-      INSTALLATION_ID: ''
+      INSTALLATION_ID: '01HTYXKF5Z6BCV7ZPB773K00Z1'
       APP_PATH: 'edge-apps/simple-message-app'
 
     steps:

--- a/.github/workflows/deploy-weather-app-qc.yml
+++ b/.github/workflows/deploy-weather-app-qc.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       APP_ID: '01HKT8ENYZFTNN5D6SJ38P9328'
+      INSTALLATION_ID: ''
       APP_PATH: 'edge-apps/weather'
 
     steps:
@@ -39,4 +40,4 @@ jobs:
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_AUTOMATED_QC }}
           # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --latest --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app version promote --latest --installation-id=${{ env.INSTALLATION_ID }} --path=${{ env.APP_PATH }}

--- a/.github/workflows/deploy-weather-app-qc.yml
+++ b/.github/workflows/deploy-weather-app-qc.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       APP_ID: '01HKT8ENYZFTNN5D6SJ38P9328'
-      INSTALLATION_ID: ''
+      INSTALLATION_ID: '01HKT8GHXJKTEVSCT90MDSB6E0'
       APP_PATH: 'edge-apps/weather'
 
     steps:

--- a/.github/workflows/deploy-weather-app.yml
+++ b/.github/workflows/deploy-weather-app.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       APP_ID: '01HKT8GYC2WW2SJTCSER92APDB'
-      INSTALLATION_ID: ''
+      INSTALLATION_ID: '01HKT8HE932HJ3WM7Q0SDHTN1N'
       APP_PATH: 'edge-apps/weather'
 
     steps:

--- a/.github/workflows/deploy-weather-app.yml
+++ b/.github/workflows/deploy-weather-app.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       APP_ID: '01HKT8GYC2WW2SJTCSER92APDB'
+      INSTALLATION_ID: ''
       APP_PATH: 'edge-apps/weather'
 
     steps:
@@ -34,4 +35,4 @@ jobs:
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
           # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --latest --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app version promote --latest --installation-id=${{ env.INSTALLATION_ID }} --path=${{ env.APP_PATH }}


### PR DESCRIPTION
New cli version 0.2.6 - for some commands(settings, secrets and promote) uses --installation-id instead of --app-id.
Updates that.

Though alternatively we could support --app-id in cli optionally for promote, but in that case we will omit checking settings, that are unset.