### PR TITLE
Edits: for the weather Edge App

### DIFF
--- a/edge-apps/weather/index.html
+++ b/edge-apps/weather/index.html
@@ -49,7 +49,7 @@
         <template x-if="fetchError">
             <div class="error">
                 <div class="group">
-                    <h2>Waiting for Internet connection...</h2>
+                    <h2 x-text="errorMessage"></h2>
                     <div class="loader"></div>
                 </div>
             </div>

--- a/edge-apps/weather/index.html
+++ b/edge-apps/weather/index.html
@@ -37,7 +37,7 @@
         </script>
         <!-- End Google Tag Manager -->
 
-        <template x-if="isLoading && !fetchError">
+        <template x-if="isLoading && !error">
             <div class="error">
                 <div class="group">
                     <h2>Loading...</h2>
@@ -46,7 +46,7 @@
             </div>
         </template>
 
-        <template x-if="fetchError">
+        <template x-if="error">
             <div class="error">
                 <div class="group">
                     <h2 x-text="errorMessage"></h2>
@@ -55,7 +55,7 @@
             </div>
         </template>
 
-        <template x-if="!fetchError">
+        <template x-if="!error">
             <div class="content">
                 <section class="header">
                     <div class="location">

--- a/edge-apps/weather/static/js/main.js
+++ b/edge-apps/weather/static/js/main.js
@@ -234,7 +234,7 @@ async function refreshWeather (context) {
         setInterval(
           () => {
             refreshDateTime(context)
-          }, 1000  // 1 second
+          }, 1000 // 1 second
         )
 
         context.firstFetchComplete = true
@@ -317,7 +317,7 @@ function getWeatherData () {
       setInterval(
         () => {
           refreshWeather(this)
-        }, 1000 * 60 * 15  // 15 minutes
+        }, 1000 * 60 * 15 // 15 minutes
       )
     },
     isLoading: true,

--- a/edge-apps/weather/static/js/main.js
+++ b/edge-apps/weather/static/js/main.js
@@ -50,11 +50,12 @@ async function getWeatherApiData (context) {
   try {
     const response = await fetch(`${endpointUrl}?${queryParams}`)
     const data = await response.json()
-    context.fetchError = false
 
     if (data.cod !== '200') {
       throw new Error(data.message)
     }
+
+    context.error = false
 
     appCache.clear()
     const { city: { name, country, timezone }, list } = data
@@ -66,6 +67,7 @@ async function getWeatherApiData (context) {
     appCache.set(result)
   } catch (error) {
     console.error(error)
+
     result = appCache.get()
 
     const requiredKeys = ['name', 'country', 'timezone', 'list']
@@ -73,7 +75,7 @@ async function getWeatherApiData (context) {
       return Object.prototype.hasOwnProperty.call(result, key)
     })
 
-    context.fetchError = !isComplete
+    context.error = !isComplete
     context.errorMessage = error.message
   }
 
@@ -216,67 +218,72 @@ const getTemp = (context, temp) => {
 }
 
 async function refreshWeather (context) {
-  const data = await getWeatherApiData(context)
+  try {
+    const data = await getWeatherApiData(context)
 
-  if (data.list !== undefined) {
-    const { name, country, timezone: tzOffset, list } = data
+    if (data.list !== undefined) {
+      const { name, country, timezone: tzOffset, list } = data
 
-    // We only want to set these values once.
-    if (!context.firstFetchComplete) {
-      context.city = `${name}, ${country}`
-      context.tzOffset = parseInt(tzOffset / 60) // in minutes
-      context.tempScale = countriesUsingFahrenheit.includes(country) ? 'F' : 'C'
+      // We only want to set these values once.
+      if (!context.firstFetchComplete) {
+        context.city = `${name}, ${country}`
+        context.tzOffset = parseInt(tzOffset / 60) // in minutes
+        context.tempScale = countriesUsingFahrenheit.includes(country) ? 'F' : 'C'
 
-      refreshDateTime(context)
-      setInterval(
-        () => {
-          refreshDateTime(context)
-        }, 1000  // 1 second
+        refreshDateTime(context)
+        setInterval(
+          () => {
+            refreshDateTime(context)
+          }, 1000  // 1 second
+        )
+
+        context.firstFetchComplete = true
+        context.isLoading = false
+      }
+
+      const currentIndex = findCurrentWeatherItem(list)
+      const { dt, weather, main: { temp } } = list[currentIndex]
+
+      if (Array.isArray(weather) && weather.length > 0) {
+        const { id, description } = weather[0]
+        const { icon, bg } = getWeatherImagesById(context, id, dt)
+        if ((id !== context.currentWeatherId) || (`bg-${bg}` !== context.bgClass)) {
+          context.bgClass = `bg-${bg}`
+        }
+
+        context.currentWeatherIcon = icons[icon]
+        context.currentWeatherStatus = description
+        context.currentTemp = getTemp(context, temp)
+        context.currentFormattedTempScale = `\u00B0${context.tempScale}`
+
+        context.currentWeatherId = id
+      }
+
+      const windowSize = 5
+      const currentWindow = list.slice(
+        currentIndex,
+        (currentIndex <= windowSize - 1)
+          ? currentIndex + windowSize
+          : list.length - 1
       )
 
-      context.firstFetchComplete = true
-      context.isLoading = false
+      context.forecastedItems = currentWindow.map((item, index) => {
+        const { dt, main: { temp }, weather } = item
+
+        const { icon } = getWeatherImagesById(context, weather[0]?.id, dt)
+        const dateTime = moment.unix(dt).utcOffset(context.tzOffset)
+
+        return {
+          id: index,
+          temp: getTemp(context, temp),
+          icon: icons[icon],
+          time: index === 0 ? 'Current' : formatTime(dateTime)
+        }
+      })
     }
-
-    const currentIndex = findCurrentWeatherItem(list)
-    const { dt, weather, main: { temp } } = list[currentIndex]
-
-    if (Array.isArray(weather) && weather.length > 0) {
-      const { id, description } = weather[0]
-      const { icon, bg } = getWeatherImagesById(context, id, dt)
-      if ((id !== context.currentWeatherId) || (`bg-${bg}` !== context.bgClass)) {
-        context.bgClass = `bg-${bg}`
-      }
-
-      context.currentWeatherIcon = icons[icon]
-      context.currentWeatherStatus = description
-      context.currentTemp = getTemp(context, temp)
-      context.currentFormattedTempScale = `\u00B0${context.tempScale}`
-
-      context.currentWeatherId = id
-    }
-
-    const windowSize = 5
-    const currentWindow = list.slice(
-      currentIndex,
-      (currentIndex <= windowSize - 1)
-        ? currentIndex + windowSize
-        : list.length - 1
-    )
-
-    context.forecastedItems = currentWindow.map((item, index) => {
-      const { dt, main: { temp }, weather } = item
-
-      const { icon } = getWeatherImagesById(context, weather[0]?.id, dt)
-      const dateTime = moment.unix(dt).utcOffset(context.tzOffset)
-
-      return {
-        id: index,
-        temp: getTemp(context, temp),
-        icon: icons[icon],
-        time: index === 0 ? 'Current' : formatTime(dateTime)
-      }
-    })
+  } catch (error) {
+    context.error = true
+    context.errorMessage = error.message
   }
 }
 
@@ -291,7 +298,8 @@ function getWeatherData () {
     currentWeatherIcon: '',
     currentWeatherId: 0,
     currentWeatherStatus: '',
-    fetchError: false,
+    error: false,
+    errorMessage: '',
     firstFetchComplete: false,
     forecastedItems: [],
     init: async function () {


### PR DESCRIPTION
Edits:
- replaced `setTimeout`(`clearTimeout`) with `setInterval`. `setInterval` is executed once on app initialization. The issue: If there is an error before setTimeout, the page will no longer be refreshed.

- replaced the default `Waiting for Internet connection...` for all errors with the proper error messages. The issue: no matter what error it will always be "Waiting for Internet connection..." which compromises our devices

- added a global try/catch for the main function. The issue: because there is no way for customers to debug the weather app and report the issues, it should be a good solution **for now** before we add CLI logging.

Some screenshots with error messages:
![Screenshot 2024-07-15 at 16-13-10 Screenly Weather App - Weather Forecast](https://github.com/user-attachments/assets/6ad5177e-73f2-48cd-92b8-68fa24085713)
![Screenshot 2024-07-15 at 16-12-52 Screenly Weather App - Weather Forecast](https://github.com/user-attachments/assets/a00ca3b0-1dde-4a1f-805c-b76f5079f409)
