### PR TITLE
Updates: all edge app actions and configuration for a big revamp of cli

### DIFF
--- a/.github/workflows/deploy-clock-app-qc.yml
+++ b/.github/workflows/deploy-clock-app-qc.yml
@@ -13,10 +13,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      APP_ID: '01HKT1XSC070BGNKYR7ZE689DE'
-      INSTALLATION_ID: '01HKT1YB1AQK79HQ5GF23F2ZAX'
-
       APP_PATH: 'edge-apps/clock'
+      MANIFEST_FILE_NAME: 'screenly_qc.yml'
 
     steps:
       - name: Checkout Code
@@ -27,18 +25,4 @@ jobs:
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_AUTOMATED_QC }}
           # yamllint disable-line rule:line-length
-          cli_commands: edge-app upload --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
-
-      - name: List Versions
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_AUTOMATED_QC }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version list --app-id=${{ env.APP_ID }}
-
-      - name: Promote Edge App
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_AUTOMATED_QC }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --latest --installation-id=${{ env.INSTALLATION_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app deploy --path=${{ env.APP_PATH }}

--- a/.github/workflows/deploy-clock-app.yml
+++ b/.github/workflows/deploy-clock-app.yml
@@ -8,9 +8,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      APP_ID: '01HKT2K8GVE8P6RE36QFKPG5G1'
-      INSTALLATION_ID: '01HKT2KZKZA270VKF3Z9PDKVJS'
-
       APP_PATH: 'edge-apps/clock'
 
     steps:
@@ -22,18 +19,4 @@ jobs:
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
           # yamllint disable-line rule:line-length
-          cli_commands: edge-app upload --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
-
-      - name: List Versions
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version list --app-id=${{ env.APP_ID }}
-
-      - name: Promote Edge App
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --latest --installation-id=${{ env.INSTALLATION_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app deploy --path=${{ env.APP_PATH }}

--- a/.github/workflows/deploy-countdown-timer-qc.yml
+++ b/.github/workflows/deploy-countdown-timer-qc.yml
@@ -13,10 +13,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      APP_ID: '01HS8ZQP09W71PAMEZ65GH6SVV'
-      INSTALLATION_ID: '01HS8ZRGW789VHMJX3N2RVM794'
-
       APP_PATH: 'edge-apps/countdown-timer'
+      MANIFEST_FILE_NAME: 'screenly_qc.yml'
 
     steps:
       - name: Checkout Code
@@ -27,18 +25,4 @@ jobs:
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_AUTOMATED_QC }}
           # yamllint disable-line rule:line-length
-          cli_commands: edge-app upload --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
-
-      - name: List Versions
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_AUTOMATED_QC }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version list --app-id=${{ env.APP_ID }}
-
-      - name: Promote Edge App
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_AUTOMATED_QC }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --latest --installation-id=${{ env.INSTALLATION_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app deploy --path=${{ env.APP_PATH }}

--- a/.github/workflows/deploy-countdown-timer.yml
+++ b/.github/workflows/deploy-countdown-timer.yml
@@ -8,9 +8,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      APP_ID: '01HS8ZSEPGFZDKE606PD038TTB'
-      INSTALLATION_ID: '01HS8ZT7KNB3MB8EAC2YET8DB2'
-
       APP_PATH: 'edge-apps/countdown-timer'
 
     steps:
@@ -22,18 +19,4 @@ jobs:
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
           # yamllint disable-line rule:line-length
-          cli_commands: edge-app upload --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
-
-      - name: List Versions
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version list --app-id=${{ env.APP_ID }}
-
-      - name: Promote Edge App
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --latest --installation-id=${{ env.INSTALLATION_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app deploy --path=${{ env.APP_PATH }}

--- a/.github/workflows/deploy-iframe-qc.yml
+++ b/.github/workflows/deploy-iframe-qc.yml
@@ -13,10 +13,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      APP_ID: '01HSGG4DJ6D2WE9GN0V7E4TSP1'
-      INSTALLATION_ID: '01HSGG5616M1JFA6Q0Z258NA4A'
-
       APP_PATH: 'edge-apps/iframe'
+      MANIFEST_FILE_NAME: 'screenly_qc.yml'
 
     steps:
       - name: Checkout Code
@@ -27,18 +25,4 @@ jobs:
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_AUTOMATED_QC }}
           # yamllint disable-line rule:line-length
-          cli_commands: edge-app upload --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
-
-      - name: List Versions
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_AUTOMATED_QC }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version list --app-id=${{ env.APP_ID }}
-
-      - name: Promote Edge App
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_AUTOMATED_QC }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --latest --installation-id=${{ env.INSTALLATION_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app deploy --path=${{ env.APP_PATH }}

--- a/.github/workflows/deploy-iframe.yml
+++ b/.github/workflows/deploy-iframe.yml
@@ -13,9 +13,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      APP_ID: '01HSGGB40HC05XK0M1WDDVEHAH'
-      INSTALLATION_ID: '01HSGGBC6HSXYFEYPN8NJ88186'
-
       APP_PATH: 'edge-apps/iframe'
 
     steps:
@@ -27,18 +24,4 @@ jobs:
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
           # yamllint disable-line rule:line-length
-          cli_commands: edge-app upload --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
-
-      - name: List Versions
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version list --app-id=${{ env.APP_ID }}
-
-      - name: Promote Edge App
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --latest --installation-id=${{ env.INSTALLATION_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app deploy --path=${{ env.APP_PATH }}

--- a/.github/workflows/deploy-iframe.yml
+++ b/.github/workflows/deploy-iframe.yml
@@ -2,12 +2,13 @@
 name: Deploy iframe app
 
 on:
-  push:
-    branches:
-      - 'master'
-    paths:
-      - 'edge-apps/iframe/**'
-      - '.github/workflows/deploy-iframe.yml'
+  workflow_dispatch:
+#  push:
+#    branches:
+#      - 'master'
+#    paths:
+#      - 'edge-apps/iframe/**'
+#      - '.github/workflows/deploy-iframe.yml'
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-power-bi-qc.yml
+++ b/.github/workflows/deploy-power-bi-qc.yml
@@ -13,9 +13,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      APP_ID: '01HRCAW49EW573V7JCH711SP5G'
-      INSTALLATION_ID: '01HRCAWQHXDAP5XZ53KZAP2SP7'
-
       APP_PATH: 'edge-apps/powerbi'
 
     steps:
@@ -27,18 +24,4 @@ jobs:
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_AUTOMATED_QC }}
           # yamllint disable-line rule:line-length
-          cli_commands: edge-app upload --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
-
-      - name: List Versions
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_AUTOMATED_QC }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version list --app-id=${{ env.APP_ID }}
-
-      - name: Promote Edge App
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_AUTOMATED_QC }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --latest --installation-id=${{ env.INSTALLATION_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app deploy --path=${{ env.APP_PATH }}

--- a/.github/workflows/deploy-power-bi.yml
+++ b/.github/workflows/deploy-power-bi.yml
@@ -13,9 +13,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      APP_ID: '01HRCB5Z5TZZFT6J37RNVQYC38'
-      INSTALLATION_ID: '01HRCBDACKA1DFNK5T1GZVX67D'
-
       APP_PATH: 'edge-apps/powerbi'
 
     steps:
@@ -27,18 +24,4 @@ jobs:
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
           # yamllint disable-line rule:line-length
-          cli_commands: edge-app upload --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
-
-      - name: List Versions
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version list --app-id=${{ env.APP_ID }}
-
-      - name: Promote Edge App
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --latest --installation-id=${{ env.INSTALLATION_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app deploy --path=${{ env.APP_PATH }}

--- a/.github/workflows/deploy-power-bi.yml
+++ b/.github/workflows/deploy-power-bi.yml
@@ -2,12 +2,13 @@
 name: Deploy Power BI
 
 on:
-  push:
-    branches:
-      - 'master'
-    paths:
-      - 'edge-apps/powerbi/**'
-      - '.github/workflows/deploy-power-bi.yml'
+  workflow_dispatch:
+#  push:
+#    branches:
+#      - 'master'
+#    paths:
+#      - 'edge-apps/powerbi/**'
+#      - '.github/workflows/deploy-power-bi.yml'
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-rss-reader-qc.yml
+++ b/.github/workflows/deploy-rss-reader-qc.yml
@@ -13,9 +13,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      APP_ID: '01HKT59B49Z343B7C2H9JVH51B'
-      INSTALLATION_ID: '01HKT5CZ14CAB58SZ8EZ1NQMMH'
       APP_PATH: 'edge-apps/rss-reader'
+      MANIFEST_FILE_NAME: 'screenly_qc.yml'
 
     steps:
       - name: Checkout Code
@@ -32,18 +31,4 @@ jobs:
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_AUTOMATED_QC }}
           # yamllint disable-line rule:line-length
-          cli_commands: edge-app upload --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
-
-      - name: List Releases
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_AUTOMATED_QC }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version list --app-id=${{ env.APP_ID }}
-
-      - name: Promote Edge App
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_AUTOMATED_QC }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --latest --installation-id=${{ env.INSTALLATION_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app deploy --path=${{ env.APP_PATH }}

--- a/.github/workflows/deploy-rss-reader.yml
+++ b/.github/workflows/deploy-rss-reader.yml
@@ -8,8 +8,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      APP_ID: '01HKT5KJPAHVGYJSFQF80BCJYQ'
-      INSTALLATION_ID: '01HKT5QZ2H4CZ0AHFTXVQ0BQ9A'
       APP_PATH: 'edge-apps/rss-reader'
 
     steps:
@@ -27,18 +25,4 @@ jobs:
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
           # yamllint disable-line rule:line-length
-          cli_commands: edge-app upload --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
-
-      - name: List Releases
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version list --app-id=${{ env.APP_ID }}
-
-      - name: Promote Edge App
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --latest --installation-id=${{ env.INSTALLATION_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app deploy --path=${{ env.APP_PATH }}

--- a/.github/workflows/deploy-simple-message-app.yml
+++ b/.github/workflows/deploy-simple-message-app.yml
@@ -8,8 +8,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      APP_ID: '01HTYXDZVA532Z1GN4CX5Z7VH7'
-      INSTALLATION_ID: '01HTYXKF5Z6BCV7ZPB773K00Z1'
       APP_PATH: 'edge-apps/simple-message-app'
 
     steps:
@@ -21,18 +19,4 @@ jobs:
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
           # yamllint disable-line rule:line-length
-          cli_commands: edge-app upload --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
-
-      - name: List Versions
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version list --app-id=${{ env.APP_ID }}
-
-      - name: Promote Edge App
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --latest --installation-id=${{ env.INSTALLATION_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app deploy --path=${{ env.APP_PATH }}

--- a/.github/workflows/deploy-tfl-bus-status-qc.yml
+++ b/.github/workflows/deploy-tfl-bus-status-qc.yml
@@ -13,9 +13,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      APP_ID: '01J013T9F09HS3TSPWF226ND18'
-      INSTALLATION_ID: '01J019M0F9QP20SRGH8H8SJHE4'
       APP_PATH: 'edge-apps/tfl-bus-status'
+      MANIFEST_FILE_NAME: 'screenly_qc.yml'
 
     steps:
       - name: Checkout Code
@@ -26,18 +25,4 @@ jobs:
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_AUTOMATED_QC }}
           # yamllint disable-line rule:line-length
-          cli_commands: edge-app upload --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
-
-      - name: List Versions
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_AUTOMATED_QC }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version list --app-id=${{ env.APP_ID }}
-
-      - name: Promote Edge App
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_AUTOMATED_QC }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --latest --installation-id=${{ env.INSTALLATION_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app deploy --path=${{ env.APP_PATH }}

--- a/.github/workflows/deploy-tfl-bus-status.yml
+++ b/.github/workflows/deploy-tfl-bus-status.yml
@@ -13,8 +13,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      APP_ID: '01J014HW843KTC13XKXV3ABD04'
-      INSTALLATION_ID: '01J014HWSD8VFYPDPFPA219EV4'
       APP_PATH: 'edge-apps/tfl-bus-status'
 
     steps:
@@ -26,18 +24,4 @@ jobs:
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
           # yamllint disable-line rule:line-length
-          cli_commands: edge-app upload --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
-
-      - name: List Versions
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version list --app-id=${{ env.APP_ID }}
-
-      - name: Promote Edge App
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --latest --installation-id=${{ env.INSTALLATION_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app deploy --path=${{ env.APP_PATH }}

--- a/.github/workflows/deploy-tfl-bus-status.yml
+++ b/.github/workflows/deploy-tfl-bus-status.yml
@@ -2,12 +2,14 @@
 name: Deploy tfl bus status app
 
 on:
-  push:
-    branches:
-      - 'master'
-    paths:
-      - 'edge-apps/tfl-bus-status/**'
-      - '.github/workflows/deploy-tfl-bus-status.yml'
+  workflow_dispatch:
+
+#  push:
+#    branches:
+#      - 'master'
+#    paths:
+#      - 'edge-apps/tfl-bus-status/**'
+#      - '.github/workflows/deploy-tfl-bus-status.yml'
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-weather-app-qc.yml
+++ b/.github/workflows/deploy-weather-app-qc.yml
@@ -13,9 +13,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      APP_ID: '01HKT8ENYZFTNN5D6SJ38P9328'
-      INSTALLATION_ID: '01HKT8GHXJKTEVSCT90MDSB6E0'
       APP_PATH: 'edge-apps/weather'
+      MANIFEST_FILE_NAME: 'screenly_qc.yml'
 
     steps:
       - name: Checkout Code
@@ -26,18 +25,4 @@ jobs:
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_AUTOMATED_QC }}
           # yamllint disable-line rule:line-length
-          cli_commands: edge-app upload --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
-
-      - name: Get Revisions
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_AUTOMATED_QC }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version list --app-id=${{ env.APP_ID }}
-
-      - name: Promote Edge App
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_AUTOMATED_QC }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --latest --installation-id=${{ env.INSTALLATION_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app deploy --path=${{ env.APP_PATH }}

--- a/.github/workflows/deploy-weather-app.yml
+++ b/.github/workflows/deploy-weather-app.yml
@@ -8,8 +8,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      APP_ID: '01HKT8GYC2WW2SJTCSER92APDB'
-      INSTALLATION_ID: '01HKT8HE932HJ3WM7Q0SDHTN1N'
       APP_PATH: 'edge-apps/weather'
 
     steps:
@@ -21,18 +19,4 @@ jobs:
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
           # yamllint disable-line rule:line-length
-          cli_commands: edge-app upload --app-id=${{ env.APP_ID }} --path=${{ env.APP_PATH }}
-
-      - name: Get Revisions
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version list --app-id=${{ env.APP_ID }}
-
-      - name: Promote Edge App
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN_PRODUCTION }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app version promote --latest --installation-id=${{ env.INSTALLATION_ID }} --path=${{ env.APP_PATH }}
+          cli_commands: edge-app deploy --path=${{ env.APP_PATH }}

--- a/edge-apps/asset-metadata/README.md
+++ b/edge-apps/asset-metadata/README.md
@@ -11,8 +11,8 @@ $ cd edge-apps/asset-metadata
 $ screenly edge-app create \
     --name my-asset-metadata \
     --in-place
-$ screenly edge-app upload
+$ screenly edge-app deploy
 [...]
+$ screenly edge-app instance create
 $ screenly edge-app secret set google_maps_api_key=Your_API_KEY
-$ screenly edge-app version promote revision=X
 ```

--- a/edge-apps/clock/.ignore
+++ b/edge-apps/clock/.ignore
@@ -1,0 +1,1 @@
+screenly_qc.yml

--- a/edge-apps/clock/README.md
+++ b/edge-apps/clock/README.md
@@ -7,11 +7,10 @@ $ cd edge-apps/clock
 $ screenly edge-app create \
     --name my-clock-app \
     --in-place
-$ screenly edge-app upload
+$ screenly edge-app deploy
 [...] # You can tweak settings here.
-$ screenly edge-app version promote --revision=X
-
-# Alternatively, you can use --latest in place of --revision.
+# To install an app, you need to create an instance.
+$ screenly edge-app instance create
 ```
 
 ## Tweaking the settings

--- a/edge-apps/clock/screenly.yml
+++ b/edge-apps/clock/screenly.yml
@@ -1,7 +1,6 @@
 ---
 syntax: manifest_v1
 id: 01HKT2K8GVE8P6RE36QFKPG5G1
-user_version: v1.0.0
 description: Screenly Clock Edge App
 icon: 'https://playground.srly.io/edge-apps/clock/static/images/icon.svg'
 author: Screenly, Inc.

--- a/edge-apps/clock/screenly_qc.yml
+++ b/edge-apps/clock/screenly_qc.yml
@@ -1,7 +1,6 @@
 ---
 syntax: manifest_v1
 id: 01HKT1XSC070BGNKYR7ZE689DE
-user_version: v1.0.0
 description: Screenly Clock Edge App
 icon: 'https://playground.srly.io/edge-apps/clock/static/images/icon.svg'
 author: Screenly, Inc.

--- a/edge-apps/clock/screenly_qc.yml
+++ b/edge-apps/clock/screenly_qc.yml
@@ -1,6 +1,6 @@
 ---
 syntax: manifest_v1
-id: 01HKT2K8GVE8P6RE36QFKPG5G1
+id: 01HKT1XSC070BGNKYR7ZE689DE
 user_version: v1.0.0
 description: Screenly Clock Edge App
 icon: 'https://playground.srly.io/edge-apps/clock/static/images/icon.svg'

--- a/edge-apps/countdown-timer/.ignore
+++ b/edge-apps/countdown-timer/.ignore
@@ -1,0 +1,1 @@
+screenly_qc.yml

--- a/edge-apps/countdown-timer/README.md
+++ b/edge-apps/countdown-timer/README.md
@@ -9,9 +9,10 @@ $ cd edge-apps/countdown-timer
 $ screenly edge-app create \
     --name countdown-timer \
     --in-place
-$ screenly edge-app upload
+$ screenly edge-app deploy
 [...] # You can tweak settings here.
-$ screenly edge-app version promote --revision=X
+# To install an app, you need to create an instance.
+$ screenly edge-app instance create
 
 # Alternatively, you can use --latest in place of --revision.
 ```

--- a/edge-apps/countdown-timer/screenly.yml
+++ b/edge-apps/countdown-timer/screenly.yml
@@ -1,7 +1,6 @@
 ---
 syntax: manifest_v1
 id: 01HS8ZSEPGFZDKE606PD038TTB
-user_version: v1.0.0
 description: Screenly Countdown Edge App
 icon: https://playground.srly.io/edge-apps/countdown-timer/static/images/icon.svg
 author: Screenly, Inc.

--- a/edge-apps/countdown-timer/screenly_qc.yml
+++ b/edge-apps/countdown-timer/screenly_qc.yml
@@ -1,6 +1,6 @@
 ---
 syntax: manifest_v1
-id: 01HS8ZSEPGFZDKE606PD038TTB
+id: 01HS8ZQP09W71PAMEZ65GH6SVV
 user_version: v1.0.0
 description: Screenly Countdown Edge App
 icon: https://playground.srly.io/edge-apps/countdown-timer/static/images/icon.svg

--- a/edge-apps/countdown-timer/screenly_qc.yml
+++ b/edge-apps/countdown-timer/screenly_qc.yml
@@ -1,7 +1,6 @@
 ---
 syntax: manifest_v1
 id: 01HS8ZQP09W71PAMEZ65GH6SVV
-user_version: v1.0.0
 description: Screenly Countdown Edge App
 icon: https://playground.srly.io/edge-apps/countdown-timer/static/images/icon.svg
 author: Screenly, Inc.

--- a/edge-apps/iframe/.ignore
+++ b/edge-apps/iframe/.ignore
@@ -1,0 +1,1 @@
+screenly_qc.yml

--- a/edge-apps/iframe/README.md
+++ b/edge-apps/iframe/README.md
@@ -32,11 +32,16 @@ Step 4. **Create a New iFrame Edge App:**
 
 Step 5. **Upload the Edge App**
 
-`$ screenly edge-app upload`
+`$ screenly edge-app deploy`
 
 > Wait for the upload to complete.
+> 
 
-Step 6. **Specify the iFrame URL**
+Step 6 **Install the Edge App**
+
+`$ screenly edge-app instance create`
+
+Step 7. **Specify the iFrame URL**
 
 Replace "WEBPAGE_URL" with the actual URL you want to display in the iFrame.
 
@@ -44,12 +49,6 @@ Replace "WEBPAGE_URL" with the actual URL you want to display in the iFrame.
 or
 
 `$ screenly edge-app setting set iframe='<iframe src="WEBPAGE_URL" title="programiz pro website" height="500" width="500" ></iframe>`
-
-Step 7. **Deploy the Edge App as Asset**
-
-`$ screenly edge-app version promote --latest`
-
-> This promotes the latest version of the Edge App as an asset.
 
 Step 8. **Check the Screenly Dashboard**
 

--- a/edge-apps/iframe/README.md
+++ b/edge-apps/iframe/README.md
@@ -35,7 +35,7 @@ Step 5. **Upload the Edge App**
 `$ screenly edge-app deploy`
 
 > Wait for the upload to complete.
-> 
+>
 
 Step 6 **Install the Edge App**
 

--- a/edge-apps/iframe/screenly_qc.yml
+++ b/edge-apps/iframe/screenly_qc.yml
@@ -1,6 +1,6 @@
 ---
 syntax: manifest_v1
-id: 01HSGGB40HC05XK0M1WDDVEHAH
+id: 01HSGG4DJ6D2WE9GN0V7E4TSP1
 description: Screenly iframe Edge App
 icon: 'https://playground.srly.io/edge-apps/iframe/static/images/icon.svg'
 author: Screenly, Inc.

--- a/edge-apps/instagram/README.md
+++ b/edge-apps/instagram/README.md
@@ -7,8 +7,9 @@ $ cd edge-apps/instagram
 $ screenly edge-app create \
     --name Instagram \
     --in-place
-$ screenly edge-app upload
+$ screenly edge-app deploy
 [...]
+# To install an app, you need to create an instance.
+$ screenly edge-app instance create
 $ screenly edge-app secret set instagram_api_token=MY_META_TOKEN
-$ screenly edge-app version promote --latest
 ```

--- a/edge-apps/instagram/screenly.yml
+++ b/edge-apps/instagram/screenly.yml
@@ -1,8 +1,8 @@
 ---
+syntax: manifest_v1
 description: Displays latest two Instagram post
 icon: 'https://playground.srly.io/edge-apps/instagram/static/images/icon.svg'
 author: Screenly, Inc.
-entrypoint: index.html
 settings:
   enable_analytics:
     type: string

--- a/edge-apps/powerbi/.ignore
+++ b/edge-apps/powerbi/.ignore
@@ -1,0 +1,1 @@
+screenly_qc.yml

--- a/edge-apps/powerbi/screenly_qc.yml
+++ b/edge-apps/powerbi/screenly_qc.yml
@@ -1,6 +1,6 @@
 ---
 syntax: manifest_v1
-id: 01HRCB5Z5TZZFT6J37RNVQYC38
+id: 01HRCAW49EW573V7JCH711SP5G
 author: Screenly, Inc.
 description: |
   Displays Power BI dashboards and reports with big focus on security.

--- a/edge-apps/qr-code/README.md
+++ b/edge-apps/qr-code/README.md
@@ -23,7 +23,13 @@ It's essential to include the dependency above or else the app will not be displ
 To deploy the example, run the following command:
 
 ```bash
-screenly edge-app upload
+screenly edge-app deploy
+```
+
+To install the app, you need to create an instance:
+
+```bash
+screenly edge-app instance create
 ```
 
 ## Using the `generateQrCode` function

--- a/edge-apps/qr-code/screenly.yml
+++ b/edge-apps/qr-code/screenly.yml
@@ -1,6 +1,5 @@
 ---
 syntax: manifest_v1
-user_version: ''
 description: A sample QR code generator app
 icon: ''
 author: Screenly, Inc.

--- a/edge-apps/qr-code/screenly.yml
+++ b/edge-apps/qr-code/screenly.yml
@@ -1,10 +1,10 @@
 ---
+syntax: manifest_v1
 user_version: ''
 description: A sample QR code generator app
 icon: ''
 author: Screenly, Inc.
 homepage_url: ''
-entrypoint: index.html
 settings:
   enable_utm:
     type: string

--- a/edge-apps/rss-reader/.ignore
+++ b/edge-apps/rss-reader/.ignore
@@ -1,0 +1,1 @@
+screenly_qc.yml

--- a/edge-apps/rss-reader/README.md
+++ b/edge-apps/rss-reader/README.md
@@ -47,8 +47,15 @@ so you need to copy the necessary files first. To do so, run the following comma
 $ screenly edge-app create \
     --name=my-rss-reader-app \
     --in-place
-$ screenly edge-app upload
+$ screenly edge-app deploy
 ```
+
+Install the app
+    
+```bash
+$ screenly edge-app instance create
+```
+
 
 Configure the feed:
 

--- a/edge-apps/rss-reader/README.md
+++ b/edge-apps/rss-reader/README.md
@@ -51,9 +51,10 @@ $ screenly edge-app deploy
 ```
 
 Install the app
-    
+
 ```bash
 $ screenly edge-app instance create
+Edge app instance successfully created.
 ```
 
 

--- a/edge-apps/rss-reader/screenly_qc.yml
+++ b/edge-apps/rss-reader/screenly_qc.yml
@@ -1,6 +1,6 @@
 ---
 syntax: manifest_v1
-id: 01HKT5KJPAHVGYJSFQF80BCJYQ
+id: 01HKT59B49Z343B7C2H9JVH51B
 description: Screenly RSS Reader App
 icon: 'https://playground.srly.io/edge-apps/rss-reader/static/images/icon.svg'
 author: Screenly, Inc.

--- a/edge-apps/simple-message-app/README.md
+++ b/edge-apps/simple-message-app/README.md
@@ -11,11 +11,10 @@ $ cd edge-apps/countdown-timer
 $ screenly edge-app create \
     --name simple-message-app \
     --in-place
-$ screenly edge-app upload
-[...] # You can tweak settings here.
-$ screenly edge-app version promote --revision=X
+$ screenly edge-app deploy
+# To install an app, you need to create an instance.
+$ screenly edge-app instance create
 
-# Alternatively, you can use --latest in place of --revision.
 ```
 
 ## Tweaking the settings

--- a/edge-apps/simple-message-app/screenly.yml
+++ b/edge-apps/simple-message-app/screenly.yml
@@ -1,7 +1,6 @@
 ---
 syntax: manifest_v1
 id: 01HTYXDZVA532Z1GN4CX5Z7VH7
-user_version: v1.0.0
 description: Screenly Simple Message App
 icon: https://playground.srly.io/edge-apps/simple-message-app/static/images/icon.svg
 author: Screenly, Inc.

--- a/edge-apps/simple-message-app/screenly.yml
+++ b/edge-apps/simple-message-app/screenly.yml
@@ -1,10 +1,10 @@
 ---
-app_id:
+syntax: manifest_v1
+id: 01HTYXDZVA532Z1GN4CX5Z7VH7
 user_version: v1.0.0
 description: Screenly Simple Message App
 icon: https://playground.srly.io/edge-apps/simple-message-app/static/images/icon.svg
 author: Screenly, Inc.
-entrypoint: index.html
 settings:
   message_header:
     type: string

--- a/edge-apps/tfl-bus-status/.ignore
+++ b/edge-apps/tfl-bus-status/.ignore
@@ -1,0 +1,1 @@
+screenly_qc.yml

--- a/edge-apps/tfl-bus-status/README.md
+++ b/edge-apps/tfl-bus-status/README.md
@@ -31,11 +31,15 @@ Replace "TFL_EdgeApp" with your desired app name.
 
 Step 5. **Upload the Edge App**
 
-`$ screenly edge-app upload`
+`$ screenly edge-app deploy`
 
 Wait for the upload to complete.
 
-Step 6. **Specify the TFL API and STOP ID** for example: 490005186S1.
+Step 6 **Create an Instance**
+
+`$ screenly edge-app instance create`
+
+Step 7. **Specify the TFL API and STOP ID** for example: 490005186S1.
 
 Replace "API" with the actual API that obtained from [https://api-portal.tfl.gov.uk/](https://api-portal.tfl.gov.uk/)
 
@@ -45,12 +49,6 @@ and provide the STOP ID also - replace the "stopID" with actual Stop ID.
 
 `$ screenly edge-app setting set stop_id=stopID`
 
-
-Step 7. **Deploy the Edge App as Asset**
-
-`$ screenly edge-app version promote --latest`
-
-This promotes the latest version of the Edge App as an asset.
 
 Step 8. **Check the Screenly Dashboard**
 

--- a/edge-apps/tfl-bus-status/screenly.yml
+++ b/edge-apps/tfl-bus-status/screenly.yml
@@ -1,7 +1,6 @@
 ---
 syntax: manifest_v1
 id: 01J014HW843KTC13XKXV3ABD04
-user_version: v1.0.0
 description: |
   Displays TFL Bus Status for a given bus stop.
   You can find the list of all bus stops here:

--- a/edge-apps/tfl-bus-status/screenly_qc.yml
+++ b/edge-apps/tfl-bus-status/screenly_qc.yml
@@ -1,6 +1,6 @@
 ---
 syntax: manifest_v1
-id: 01J014HW843KTC13XKXV3ABD04
+id: 01J013T9F09HS3TSPWF226ND18
 user_version: v1.0.0
 description: |
   Displays TFL Bus Status for a given bus stop.

--- a/edge-apps/tfl-bus-status/screenly_qc.yml
+++ b/edge-apps/tfl-bus-status/screenly_qc.yml
@@ -1,7 +1,6 @@
 ---
 syntax: manifest_v1
 id: 01J013T9F09HS3TSPWF226ND18
-user_version: v1.0.0
 description: |
   Displays TFL Bus Status for a given bus stop.
   You can find the list of all bus stops here:

--- a/edge-apps/weather/.ignore
+++ b/edge-apps/weather/.ignore
@@ -1,0 +1,1 @@
+screenly_qc.yml

--- a/edge-apps/weather/README.md
+++ b/edge-apps/weather/README.md
@@ -9,7 +9,7 @@ $ cd edge-apps/weather
 $ screenly edge-app create \
     --name=EDGE_APP_NAME \
     --in-place
-$ screenly edge-app upload
+$ screenly edge-app deploy
+$ screenly edge-app instance create
 $ screenly edge-app secret set openweathermap_api_key=MY_API_KEY
-$ screenly edge-app version promote revision=X
 ```

--- a/edge-apps/weather/screenly_qc.yml
+++ b/edge-apps/weather/screenly_qc.yml
@@ -1,6 +1,6 @@
 ---
 syntax: manifest_v1
-id: 01HKT8GYC2WW2SJTCSER92APDB
+id: 01HKT8ENYZFTNN5D6SJ38P9328
 description: Displays the current weather and time
 icon: 'https://playground.srly.io/edge-apps/weather/static/images/icon.svg'
 author: Screenly, Inc.


### PR DESCRIPTION
This PR is draft as 
 - cli version is not released yet.
 - workflows are not tested - will be tested after cli release.

It changes:
- all the workflows for edge-apps to use new changed command deploy instead of upload/promote.
- READMEs to reflect the changes
- removed --app-id argument as it is not used - id is read from screenly.yml file
- For qc workflows adds override of the screenly.yml file.

Note: 
This page should be changed to reflect the changes in cli: https://www.screenly.io/tutorials/powerbi/
