### PR TITLE
Edits: some Edge App settings to global

### DIFF
--- a/edge-apps/clock/screenly.yml
+++ b/edge-apps/clock/screenly.yml
@@ -11,6 +11,7 @@ settings:
     title: Enable Analytics
     optional: true
     help_text: Whether to disable Sentry and Google Analytics integrations
+    is_global: true
   override_timezone:
     type: string
     default_value: ''
@@ -29,3 +30,4 @@ settings:
     title: Google Tag Manager ID
     optional: true
     help_text: Specify a Google Tag Manager ID
+    is_global: true

--- a/edge-apps/clock/screenly_qc.yml
+++ b/edge-apps/clock/screenly_qc.yml
@@ -11,6 +11,7 @@ settings:
     title: Enable Analytics
     optional: true
     help_text: Whether to disable Sentry and Google Analytics integrations
+    is_global: true
   override_timezone:
     type: string
     default_value: ''
@@ -29,3 +30,4 @@ settings:
     title: Google Tag Manager ID
     optional: true
     help_text: Specify a Google Tag Manager ID
+    is_global: true

--- a/edge-apps/countdown-timer/screenly.yml
+++ b/edge-apps/countdown-timer/screenly.yml
@@ -18,6 +18,7 @@ settings:
     title: enable_analytics
     optional: true
     help_text: Whether to disable Sentry and Google Analytics integrations
+    is_global: true
   override_locale:
     type: string
     default_value: en
@@ -42,6 +43,7 @@ settings:
     title: tag_manager_id
     optional: true
     help_text: Specify a Google Tag Manager ID
+    is_global: true
   target_timestamp:
     type: string
     default_value: 2025-01-01T00:00:00

--- a/edge-apps/countdown-timer/screenly_qc.yml
+++ b/edge-apps/countdown-timer/screenly_qc.yml
@@ -18,6 +18,7 @@ settings:
     title: enable_analytics
     optional: true
     help_text: Whether to disable Sentry and Google Analytics integrations
+    is_global: true
   override_locale:
     type: string
     default_value: en
@@ -36,6 +37,7 @@ settings:
     title: tag_manager_id
     optional: true
     help_text: Specify a Google Tag Manager ID
+    is_global: true
   target_timestamp:
     type: string
     default_value: 2025-01-01T00:00:00

--- a/edge-apps/rss-reader/screenly.yml
+++ b/edge-apps/rss-reader/screenly.yml
@@ -25,6 +25,7 @@ settings:
     title: Enable Analytics
     optional: true
     help_text: Whether to enable analytics or not
+    is_global: true
   limit:
     type: string
     default_value: '4'
@@ -49,3 +50,4 @@ settings:
     title: Google Tag Manager ID
     optional: true
     help_text: Specify a Google Tag Manager ID
+    is_global: true

--- a/edge-apps/rss-reader/screenly_qc.yml
+++ b/edge-apps/rss-reader/screenly_qc.yml
@@ -25,6 +25,7 @@ settings:
     title: Enable Analytics
     optional: true
     help_text: Whether to enable analytics or not
+    is_global: true
   limit:
     type: string
     default_value: '4'
@@ -49,3 +50,4 @@ settings:
     title: Google Tag Manager ID
     optional: true
     help_text: Specify a Google Tag Manager ID
+    is_global: true

--- a/edge-apps/weather/screenly.yml
+++ b/edge-apps/weather/screenly.yml
@@ -11,6 +11,7 @@ settings:
     title: Enable Analytics
     optional: true
     help_text: Whether to enable analytics or not
+    is_global: true
   openweathermap_api_key:
     type: secret
     title: Openweathermap API Key
@@ -24,6 +25,7 @@ settings:
     title: Google Tag Manager ID
     optional: true
     help_text: Specify a Google Tag Manager ID
+    is_global: true
   override_coordinates:
     type: string
     default_value: ''

--- a/edge-apps/weather/screenly_qc.yml
+++ b/edge-apps/weather/screenly_qc.yml
@@ -11,6 +11,7 @@ settings:
     title: Enable Analytics
     optional: true
     help_text: Whether to enable analytics or not
+    is_global: true
   openweathermap_api_key:
     type: secret
     title: Openweathermap API Key
@@ -24,6 +25,7 @@ settings:
     title: Google Tag Manager ID
     optional: true
     help_text: Specify a Google Tag Manager ID
+    is_global: true
   override_coordinates:
     type: string
     default_value: ''


### PR DESCRIPTION
Edge App settings to global:
- `enable_analytics`
- `tag_manager_id`

Note:
- `ready_for_rendering` will be deleted from the backend