### PR TITLE
Set Default locale in Clock App For Stability - QC yml only. 

### DIFF
--- a/edge-apps/clock/screenly_qc.yml
+++ b/edge-apps/clock/screenly_qc.yml
@@ -21,7 +21,7 @@ settings:
     help_text: Specify a supported timezone value (e.g., Europe/London).
   override_locale:
     type: string
-    default_value: ''
+    default_value: en
     title: Override Locale
     optional: true
     help_text: Specify a supported locale value (e.g., en_US).


### PR DESCRIPTION
I set default locale as **en** for standard 

   default_value: en``