### PR TITLE
feat: enable some containers to occupy unused space

### DIFF
--- a/edge-apps/simple-message-app/static/css/style.css
+++ b/edge-apps/simple-message-app/static/css/style.css
@@ -268,6 +268,7 @@
 
 .primary-card {
   width: 100%;
+  height: 100%;
 }
 
 .primary-container {
@@ -276,6 +277,7 @@
 
 .secondary-container {
   width: 35%;
+  height: 100%;
 }
 
 .primary-card.message-body {


### PR DESCRIPTION
### Overview

> [!CAUTION]
> **Do not** merge this pull request.

### Screenshots

#### 480x800

![image](https://github.com/user-attachments/assets/20af41a3-ddfa-4230-9528-d36c1eb299f3)

@salmanfarisvp, if we want the second/middle row to be after the message body, then using grid might give you more flexibility.