### PR TITLE
fix: strip HTML tags (if present) while preserving RSS feed content

### DIFF
--- a/edge-apps/rss-reader/static/js/main.js
+++ b/edge-apps/rss-reader/static/js/main.js
@@ -96,9 +96,9 @@ const getRssData = function () {
             const response = (await getApiResponse(this)).slice(0, 4)
             this.fetchError = false
             appCache.clear()
-            const entries = response.map(({ title, pubDate, content, contentSnippet }) => {
+            const entries = response.map(({ title, pubDate, content }) => {
               // Process HTML content if present
-              let processedContent = contentSnippet || content || ''
+              let processedContent = content || ''
               if (content && content.includes('<')) {
                 // Strip HTML tags while preserving text content
                 processedContent = content
@@ -107,7 +107,7 @@ const getRssData = function () {
                   .trim()
               }
 
-              return { title, pubDate, content: processedContent, contentSnippet }
+              return { title, pubDate, content: processedContent }
             })
 
             this.entries = entries

--- a/edge-apps/rss-reader/static/js/main.js
+++ b/edge-apps/rss-reader/static/js/main.js
@@ -97,7 +97,17 @@ const getRssData = function () {
             this.fetchError = false
             appCache.clear()
             const entries = response.map(({ title, pubDate, content, contentSnippet }) => {
-              return { title, pubDate, content, contentSnippet }
+              // Process HTML content if present
+              let processedContent = contentSnippet || content || ''
+              if (content && content.includes('<')) {
+                // Strip HTML tags while preserving text content
+                processedContent = content
+                  .replace(/<[^>]*>/g, '')
+                  .replace(/\s+/g, ' ')
+                  .trim()
+              }
+
+              return { title, pubDate, content: processedContent, contentSnippet }
             })
 
             this.entries = entries


### PR DESCRIPTION
### **User description**
### Issues Fixed

- Fixes #220 

### Screenshots

#### Screenly RSS Feed

Before

![image](https://github.com/user-attachments/assets/f8575c35-6de5-4cf5-8f08-7f1630c44d1b)

After

![image](https://github.com/user-attachments/assets/28214520-5247-4b05-b818-99fb0c24e284)


#### BBC RSS Feed

![image](https://github.com/user-attachments/assets/1fa341a2-e784-4fdb-ae92-583993336a0f)


___

### **PR Type**
- Enhancement



___

### **Description**
- Strip HTML tags from RSS feed content

- Remove unused 'contentSnippet' mapping

- Clean and trim HTML stripped text


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.js</strong><dd><code>Strip HTML tags and remove unused contentSnippet</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

edge-apps/rss-reader/static/js/main.js

<li>Added HTML tag stripping for content field<br> <li> Removed 'contentSnippet' from mapping<br> <li> Cleaned up whitespace in content processing


</details>


  </td>
  <td><a href="https://github.com/Screenly/Playground/pull/221/files#diff-20d9423959a1ee4dea235951327e39a7e760b71f28d09177bfa5c3289a64ea7a">+12/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>