### PR TITLE
Exclude .svg files from JSCPD to avoid false positives

### DIFF
--- a/.github/linters/.jscpd.json
+++ b/.github/linters/.jscpd.json
@@ -1,10 +1,13 @@
 {
-    "threshold": 0,
-    "reporters": [
-      "consoleFull"
-    ],
-    "ignore": [
-      "**/__snapshots__/**", "**/*.html", "**/*.css"
-    ],
-    "absolute": true
-  }
+  "threshold": 0,
+  "reporters": [
+    "consoleFull"
+  ],
+  "ignore": [
+    "**/__snapshots__/**",
+    "**/*.html",
+    "**/*.css",
+    "**/*.svg"
+  ],
+  "absolute": true
+}


### PR DESCRIPTION
### **User description**
This PR updates the .jscpd.json configuration to exclude .svg files from duplicate code checks using JSCPD (Copy/Paste Detector).

Related - https://github.com/Screenly/Playground/pull/228#issuecomment-2800501502

**Changes Made**
Added "`**/*.svg`" to the ignore list in .jscpd.json

**Impact**
JSCPD will now ignore `.svg `files, reducing false positives and unnecessary CI failures.


___

### **PR Type**
- Enhancement



___

### **Description**
- Add SVG exclusion to JSCPD config.

- Update ignore list in .github/linters/.jscpd.json.

- Reduce false positives in duplicate detection.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.jscpd.json</strong><dd><code>Add SVG Exclusion in JSCPD Ignore List</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/linters/.jscpd.json

<li>Appended "**/*.svg" to the ignore list.<br> <li> Maintained existing threshold and reporters.<br> <li> Reordered JSON formatting for clarity.


</details>


  </td>
  <td><a href="https://github.com/Screenly/Playground/pull/230/files#diff-557094e283c00b23265c1c75872f41c6b1a524a00f0d99dd68ebd22cb63bfdd6">+12/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>