### PR TITLE
chore(ci): configure Webpack to lookup env var for the manifest file path

### DIFF
--- a/edge-apps/google-calendar/webpack.common.js
+++ b/edge-apps/google-calendar/webpack.common.js
@@ -5,6 +5,8 @@ const RemovePlugin = require('remove-files-webpack-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const webpack = require('webpack')
 
+const manifestFileName = process.env.MANIFEST_FILE_NAME || 'screenly.yml'
+
 module.exports = {
   entry: {
     index: './src/index.jsx'
@@ -48,8 +50,8 @@ module.exports = {
     new CopyWebpackPlugin({
       patterns: [
         {
-          from: 'screenly.yml',
-          to: 'screenly.yml'
+          from: manifestFileName,
+          to: manifestFileName
         },
         {
           from: 'src/img',


### PR DESCRIPTION
### Issues Fixes

Fixes QC deployment error for the calendar Edge App. See [this workflow run](https://github.com/Screenly/Playground/actions/runs/14933579670/job/41955642934) for details.

```
Failed to upload edge app: Manifest file validation failed with error: Edge App Manifest (screenly.yml) doesn't exist under provided path: edge-apps/google-calendar/dist/screenly_qc.yml. Enter a valid command line --path parameter or invoke command in a directory containing Edge App Manifest.
```