### PR TITLE
Fix Edge App Initialisation GH Action. 

### DIFF
--- a/.github/workflows/initialize-app.yml
+++ b/.github/workflows/initialize-app.yml
@@ -1,71 +1,83 @@
----
 name: Initialize Edge App
-description: This action creates an edge app in the main repository
+description: |
+  This action creates and initializes a new edge app in the repository,
+  including its deployment and instance setup for the specified environment.
 
 on:
   workflow_dispatch:
-    # input environment
     inputs:
       environment:
-        description: 'Environment to deploy to'
+        description: 'Target environment for initialization (staging or production)'
         required: true
-        default: 'production'
+        default: 'staging'
         type: choice
         options:
-          - production
           - staging
+          - production
 
       edge_app_name:
-        description: 'Name of the edge app'
+        description: 'Folder name of the edge app (under edge-apps/) to initialize'
         required: true
         default: ''
-        type: string
 
       edge_app_title:
-        description: 'Title of the edge app'
+        description: 'Display title of the edge app (used in instance.yml)'
         required: true
         default: ''
-        type: string
+
+run-name: Initializing ${{ inputs.edge_app_name }} in ${{ inputs.environment }}
 
 jobs:
   deploy:
-    environment: ${{ github.event.inputs.environment }}
+    name: Initialize App in ${{ inputs.environment }}
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
     env:
-      APP_PATH: 'edge-apps/fake-dashboard'
+      APP_PATH: edge-apps/${{ inputs.edge_app_name }}
+      MANIFEST_FILE_NAME: ${{ inputs.environment == 'production' && 'screenly.yml' || 'screenly_qc.yml' }}
 
     steps:
-      - name: Checkout Code
+      - name: Checkout master branch
         uses: actions/checkout@v4
+        with:
+          ref: master
 
       - name: Create Edge App
         uses: screenly/cli@master
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app create --in-place --path=edge-apps/${{ inputs.edge_app_name }}
+          cli_commands: edge-app create --in-place --path=${{ env.APP_PATH }}
 
       - name: Deploy Edge App
         uses: screenly/cli@master
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app deploy --path=edge-apps/${{ inputs.edge_app_name }}
+          cli_commands: edge-app deploy --path=${{ env.APP_PATH }}
 
       - name: Create Edge App Instance
         uses: screenly/cli@master
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN }}
-          # yamllint disable-line rule:line-length
-          cli_commands: edge-app instance create --path=edge-apps/${{ inputs.edge_app_name }}
+          cli_commands: edge-app instance create --path=${{ env.APP_PATH }}
 
       - name: Correct the instance name
         run: |
-          cd edge-apps/${{ inputs.edge_app_name }}
-          sed -i "s/^name: .*/name: ${{ inputs.edge_app_title }}/" instance.yml
+          sed -i "s/^name: .*/name: ${{ inputs.edge_app_title }}/" ${{ env.APP_PATH }}/instance.yml
 
       - name: Update Edge App Instance
         uses: screenly/cli@master
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN }}
-          cli_commands: edge-app instance update --path=edge-apps/${{ inputs.edge_app_name }}
+          cli_commands: edge-app instance update --path=${{ env.APP_PATH }}
+
+      - name: Install yq (YAML parser)
+        run: |
+          sudo apt-get update && sudo apt-get install -y yq
+
+      - name: Print Edge App ID from manifest
+        run: |
+          MANIFEST_FILE="${{ env.APP_PATH }}/${{ env.MANIFEST_FILE_NAME }}"
+          echo " Reading App ID from: $MANIFEST_FILE"
+          APP_ID=$(yq '.id' "$MANIFEST_FILE")
+          echo " Edge App ID: $APP_ID"
+        shell: bash


### PR DESCRIPTION
This PR refactors and enhances the existing Initialize Edge App GitHub Action to streamline Edge App initialization for both production and QC environments.

- Introduces dynamic `APP_PATH` based on user input
- Adds environment-based manifest detection (**screenly.yml** vs **screenly_qc.yml**)
- Uses run-name to reflect app name and target environment for easier tracking
- Adds a debug step to read and print the` Edge App ID `from the manifest using yq - Later we can use it for the **Edge App APP ID**. 

### Why This Matters:
In the past, a Screenly admin had to manually install the app in:
- The automated-qc account via CLI to generate and retrieve the screenly_qc.yml App ID
- The production account via CLI to retrieve the screenly.yml App ID
- This manual process was error-prone and time-consuming.

@renatgalimov  proposed this improvement to simplify the process. With this new action, admins can now run the workflow once to generate both App IDs automatically, without needing to do any manual CLI installations. This improves both efficiency and consistency in our app deployment process.


