### PR TITLE
Fix Edge App inIitialize Github Workflow

### DIFF
--- a/.github/workflows/initialize-app.yml
+++ b/.github/workflows/initialize-app.yml
@@ -24,11 +24,9 @@ on:
         required: true
         default: ''
 
-run-name: Initializing ${{ inputs.edge_app_name }} in ${{ inputs.environment }}
-
 jobs:
   deploy:
-    name: Initialize App in ${{ inputs.environment }}
+    name: Initializing ${{ inputs.edge_app_name }} in ${{ inputs.environment }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     env:
@@ -61,7 +59,7 @@ jobs:
 
       - name: Correct the instance name
         run: |
-          sed -i "s/^name: .*/name: ${{ inputs.edge_app_title }}/" ${{ env.APP_PATH }}/instance.yml
+          sed -i "s/^name: .*/name: ${{ inputs.edge_app_title }}/" "${{ env.APP_PATH }}/instance.yml"
 
       - name: Update Edge App Instance
         uses: screenly/cli@master
@@ -69,14 +67,19 @@ jobs:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN }}
           cli_commands: edge-app instance update --path=${{ env.APP_PATH }}
 
-      - name: Install yq (YAML parser)
-        run: |
-          sudo apt-get update && sudo apt-get install -y yq
+      - name: Install yq
+        uses: mikefarah/yq@v4
 
       - name: Print Edge App ID from manifest
         run: |
           MANIFEST_FILE="${{ env.APP_PATH }}/${{ env.MANIFEST_FILE_NAME }}"
-          echo " Reading App ID from: $MANIFEST_FILE"
+          echo "Reading App ID from: $MANIFEST_FILE"
           APP_ID=$(yq '.id' "$MANIFEST_FILE")
-          echo " Edge App ID: $APP_ID"
+
+          if [ -z "$APP_ID" ]; then
+            echo "❌ App ID not found in manifest!"
+            exit 1
+          fi
+
+          echo "✅ Edge App ID: $APP_ID"
         shell: bash


### PR DESCRIPTION
### **User description**
- [X] Added **--name** to **edge-app create**
- [X] Moved dynamic run name to jobs.deploy.name (from invalid top-level use).
- [X] Kept SCREENLY_API_TOKEN environment-scoped, no custom conditional logic needed.
- [X] Switched yq installation to use mikefarah/yq@v4 action (faster, cleaner).
- [X] Added null check when reading App ID from the manifest.
- [X] Uploaded instance.yml and manifest as downloadable artifacts for review/debugging.
- [X]  Cleaned up and validated env vars like APP_PATH and MANIFEST_FILE_NAME.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added `--name` flag in edge-app create

- Added manifest ID null-check and exit

- Replaced yq install with mikefarah/yq@v4

- Updated job name and refined file quoting


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>initialize-app.yml</strong><dd><code>Enhance workflow naming and error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/initialize-app.yml

<li>Job name now includes <code>inputs.edge_app_name</code><br> <li> Added <code>--name</code> option to edge-app create<br> <li> Replaced apt yq install with mikefarah/yq@v4<br> <li> Added App ID null-check, exit on missing ID, refined file quoting


</details>


  </td>
  <td><a href="https://github.com/Screenly/Playground/pull/268/files#diff-aa6053abeb1aada4d6abc59efda978151637f1b39550d94070a49f5cd2ca5ec8">+14/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>