### PR TITLE
chore(ci): remove trailing slash from API_BASE_URL values

### DIFF
--- a/.github/workflows/initialize-app.yml
+++ b/.github/workflows/initialize-app.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     env:
-      API_BASE_URL: ${{ inputs.environment == 'stage' && 'https://api.screenlyappstage.com/' || 'https://api.screenlyapp.com/' }}
+      API_BASE_URL: ${{ inputs.environment == 'stage' && 'https://api.screenlyappstage.com' || 'https://api.screenlyapp.com' }}
       APP_NAME: ${{ inputs.edge_app_name }}
       APP_PATH: edge-apps/${{ inputs.edge_app_name }}
       SCREENLY_API_TOKEN: ${{ secrets.SCREENLY_API_TOKEN }}


### PR DESCRIPTION
### **User description**
### Issues Fixed

Resolves the following issue encountered when trying to deploy the calendar Edge App via CI

```
2025-06-11T17:52:58.719Z DEBUG [hyper::client::pool] pooling idle connection for ("https", api.screenlyapp.com)
2025-06-11T17:52:58.720Z DEBUG [screenly::commands::edge_app::app] Response: Ok("{\"code\":\"PGRST102\",\"error\":\"Empty body or malformed JSON.\"}")
```

### Description

Removes trailing spaces from `API_BASE_URL` values


___

### **PR Type**
Bug fix


___

### **Description**
- Removed trailing slash from API_BASE_URL

- Fix malformed JSON API error


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>initialize-app.yml</strong><dd><code>Remove trailing slashes in API_BASE_URL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/initialize-app.yml

<li>Removed trailing slash from stage API URL<br> <li> Removed trailing slash from production API URL


</details>


  </td>
  <td><a href="https://github.com/Screenly/Playground/pull/287/files#diff-aa6053abeb1aada4d6abc59efda978151637f1b39550d94070a49f5cd2ca5ec8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>