### PR TITLE
chore(ci): make the manifest file path depend on `MANIFEST_FILE_NAME`

### DIFF
--- a/.github/workflows/initialize-app.yml
+++ b/.github/workflows/initialize-app.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: 📋 Log screenly.yml
         run: |
-          cat ${{ env.APP_PATH }}/screenly.yml
+          cat ${{ env.APP_PATH }}/${{ env.MANIFEST_FILE_NAME }}
 
       - name: 📄 Create Instance
         uses: screenly/cli@master


### PR DESCRIPTION
### **User description**
- This pull request is a follow-up to #287


___

### **PR Type**
Enhancement


___

### **Description**
- Use `MANIFEST_FILE_NAME` for manifest path

- Replace hardcoded `screenly.yml` reference


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>initialize-app.yml</strong><dd><code>Use variable manifest file path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/initialize-app.yml

<li>Replaced hardcoded <code>screenly.yml</code> with <code>env.MANIFEST_FILE_NAME</code><br> <li> Updated <code>cat</code> command to use <code>MANIFEST_FILE_NAME</code> variable


</details>


  </td>
  <td><a href="https://github.com/Screenly/Playground/pull/289/files#diff-aa6053abeb1aada4d6abc59efda978151637f1b39550d94070a49f5cd2ca5ec8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>