### PR TITLE
chore(ci): add an `API_BASE_URL` env var in the Edge App update workflow

### DIFF
--- a/.github/workflows/update-edge-app.yml
+++ b/.github/workflows/update-edge-app.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     env:
+      API_BASE_URL: ${{ inputs.environment == 'stage' && 'https://api.screenlyappstage.com' || 'https://api.screenlyapp.com' }}
       APP_PATH: edge-apps/${{ inputs.edge_app_name }}
       MANIFEST_FILE_NAME: ${{ inputs.environment == 'stage' && 'screenly_qc.yml' || 'screenly.yml' }}
       SCREENLY_API_TOKEN: ${{ secrets.SCREENLY_API_TOKEN }}


### PR DESCRIPTION
### Description

Fixes issue with deploying changes to the Edge App when [update-edge-app.yml](https://github.com/Screenly/Playground/actions/workflows/update-edge-app.yml) workflow is triggered.

```
2025-07-02T17:14:11.382Z DEBUG [reqwest::connect] starting new connection: https://api.screenlyapp.com/
2025-07-02T17:14:11.383Z DEBUG [hyper::client::connect::dns] resolving host="api.screenlyapp.com"
2025-07-02T17:14:11.445Z DEBUG [hyper::client::connect::http] connecting to 104.18.28.52:443
2025-07-02T17:14:11.447Z DEBUG [hyper::client::connect::http] connected to 104.18.28.52:443
2025-07-02T17:14:11.453Z DEBUG [hyper::proto::h1::io] flushed 338 bytes
2025-07-02T17:14:11.496Z DEBUG [hyper::proto::h1::io] parsed 11 headers
2025-07-02T17:14:11.496Z DEBUG [hyper::proto::h1::conn] incoming body is chunked encoding
2025-07-02T17:14:11.496Z DEBUG [hyper::proto::h1::decode] incoming chunked header: 0x5F (95 bytes)
2025-07-02T17:14:11.496Z DEBUG [hyper::proto::h1::conn] incoming body completed
2025-07-02T17:14:11.496Z DEBUG [hyper::client::pool] pooling idle connection for ("https", api.screenlyapp.com)
Response: Ok("{\"code\":\"42501\",\"error\":\"Authentication failed. Please provide correct authentication header.\"}")	
```

Take note that for deploying changes to the staging instance, the URL should be `https://api.screenlyappstage.com` and not `https://api.screenlyapp.com`.