### PR TITLE
feat: make Google Calendar app's OAuth credentials optional

### DIFF
--- a/edge-apps/google-calendar/screenly.yml
+++ b/edge-apps/google-calendar/screenly.yml
@@ -33,12 +33,12 @@ settings:
   client_id:
     type: secret
     title: Google OAuth Client ID
-    optional: false
+    optional: true
     help_text: Specify the Google OAuth Client ID
   client_secret:
     type: secret
     title: Google OAuth Client Secret
-    optional: false
+    optional: true
     help_text: Specify the Google OAuth Client Secret
   enable_analytics:
     type: string

--- a/edge-apps/google-calendar/screenly_qc.yml
+++ b/edge-apps/google-calendar/screenly_qc.yml
@@ -33,12 +33,12 @@ settings:
   client_id:
     type: secret
     title: Google OAuth Client ID
-    optional: false
+    optional: true
     help_text: Specify the Google OAuth Client ID
   client_secret:
     type: secret
     title: Google OAuth Client Secret
-    optional: false
+    optional: true
     help_text: Specify the Google OAuth Client Secret
   enable_analytics:
     type: string


### PR DESCRIPTION
- Since users can now choose either `api` (Google OAuth credentials) or `ical` (iCal URL) for `calendar_source_type` (i.e., the data source, Google OAuth credentials must be optional.
- For instance, if users prefer to use just their Google Calendar iCal URL, they don't need to specify Google OAuth credentials like the client ID, the client secret, and the refresh token.
- Take note that the `refresh_token` is already an optional field.