### PR TITLE
fix: '...' appears instead of the time for monthly calendar view

### DIFF
--- a/edge-apps/google-calendar/src/utils.js
+++ b/edge-apps/google-calendar/src/utils.js
@@ -30,7 +30,8 @@ export const getFormattedTime = async (
   date = new Date(),
   locale = null
 ) => {
-  const hourCycles = new Intl.Locale(locale || await getLocale()).hourCycles
+  const resolvedLocale = locale || await getLocale()
+  const hourCycles = new Intl.Locale(resolvedLocale).hourCycles
   let hourFormat = 'numeric'
 
   if (hourCycles?.length === 1) {
@@ -41,7 +42,7 @@ export const getFormattedTime = async (
     }
   }
 
-  return date.toLocaleTimeString(await getLocale(), {
+  return date.toLocaleTimeString(resolvedLocale, {
     hour: hourFormat,
     minute: '2-digit',
     timeZone: getTimeZone()


### PR DESCRIPTION
### Issues Fixed

Screenshot(s) will be added shortly.

### Description

- Refactors calls to `getLocale()` to prevent "Maximum call stack exceeded errors" due to `getLocale()` being called recursively and indefinitely, resulting to "..." being rendered.