### PR TITLE
feat: use a different shade of red for the Sunday column

### DIFF
--- a/edge-apps/google-calendar/src/css/style.css
+++ b/edge-apps/google-calendar/src/css/style.css
@@ -5,7 +5,7 @@
 /* Override Colors */
 :root {
   --theme-color-secondary: #c9cdd0;
-  --theme-color-accent: #f7410a;
+  --theme-color-accent: #ffb092;
   --theme-color-text: #000;
 }
 


### PR DESCRIPTION
### **User description**
### Before

<img width="428" height="464" alt="image" src="https://github.com/user-attachments/assets/1777337b-c2d6-416a-9473-3821942b6e2a" />

### After

<img width="428" height="464" alt="image" src="https://github.com/user-attachments/assets/e5ae20c7-9990-4434-819b-b4a3a41fda6b" />


___

### **PR Type**
Enhancement


___

### **Description**
- Updated accent theme color to lighter shade


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>style.css</strong><dd><code>Update accent CSS variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

edge-apps/google-calendar/src/css/style.css

- Changed `--theme-color-accent` from `#f7410a` to `#ffb092`


</details>


  </td>
  <td><a href="https://github.com/Screenly/Playground/pull/301/files#diff-638e1b0011196c4c38e65351f1dbdc4575e714a001bb479fcf01703c7e473b34">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>