### PR TITLE
chore: disable TypeScript linting (via super-linter)

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -52,4 +52,7 @@ jobs:
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_HTML: false
+          VALIDATE_TYPESCRIPT_ES: false
+          VALIDATE_TYPESCRIPT_PRETTIER: false
+          VALIDATE_TYPESCRIPT_STANDARD: false
           DEFAULT_BRANCH: master


### PR DESCRIPTION
### **User description**

- As we transition our Edge Apps' source code to use Vue and Typescript, we have to disable TypeScript validation via [super-linter](https://github.com/super-linter/super-linter).
- Moving forward, all Edge Apps that will be ported and created will be self-contained, which means that each of them have their own set of dependencies installed.
- Running linting and formatting could be done bu running&mdash;`bun run lint && bun run format`.
- We might be dropping the use of super-linter in the future.


___

### **PR Type**
Other


___

### **Description**
- Disable TypeScript ES lint validation

- Disable TypeScript Prettier validation

- Disable TypeScript Standard validation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>linter.yml</strong><dd><code>Disable TypeScript validations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/linter.yml

<li>Added <code>VALIDATE_TYPESCRIPT_ES: false</code><br> <li> Added <code>VALIDATE_TYPESCRIPT_PRETTIER: false</code><br> <li> Added <code>VALIDATE_TYPESCRIPT_STANDARD: false</code>


</details>


  </td>
  <td><a href="https://github.com/Screenly/Playground/pull/305/files#diff-ba16fc050e9c818b8125acc6d33b13f4c427ca91373d286af13d0fc92da90605">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>