### PR TITLE
ci(dependabot): include bun template directory in updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
   - package-ecosystem: "bun"
     directories:
       - "edge-apps/*"
+      - "edge-apps/.bun-create/edge-app-template"
     schedule:
       interval: "weekly"
 


### PR DESCRIPTION
* Adds edge-apps/.bun-create/edge-app-template to Dependabot bun directories to ensure template deps are tracked.