### PR TITLE
chore(deps): increase freq of dependency updates; group deps into fewer PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,26 @@ updates:
       - "edge-apps/*"
       - "edge-apps/.bun-create/edge-app-template"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    groups:
+      bun:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/edge-apps/queue-management-system/server"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    groups:
+      pip:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
### **User description**
- Changed the frequency of doing Dependabot updates from `weekly` to `daily`
- Added rules for GitHub Actions
- Groups dependency updates according to ecosystem (e.g., `npm`, `pip`, `github-actions`)


___

### **PR Type**
Enhancement, Configuration changes


___

### **Description**
Increase Dependabot update frequency to daily
Add grouping for bun, pip, actions
Enable Dependabot for GitHub Actions
Apply groups with wildcard patterns


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dependabot config"] -- "increase frequency" --> B["Daily updates"]
  A -- "add groups" --> C["Ecosystem groups"]
  A -- "new ecosystem" --> D["GitHub Actions"]
  C -- "bun/pip/actions" --> E["Wildcard patterns (*)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot.yml</strong><dd><code>Daily updates and grouped ecosystems in Dependabot</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/dependabot.yml

<ul><li>Change schedules from weekly to daily<br> <li> Add groups for bun, pip, actions<br> <li> Introduce GitHub Actions ecosystem entry<br> <li> Use wildcard patterns for grouping</ul>


</details>


  </td>
  <td><a href="https://github.com/Screenly/Playground/pull/363/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28">+19/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

