### PR TITLE
fix: only add events that fall within the visible time range except hour 0

### DIFF
--- a/edge-apps/google-calendar/src/components/WeeklyCalendarView.vue
+++ b/edge-apps/google-calendar/src/components/WeeklyCalendarView.vue
@@ -62,9 +62,13 @@ const eventMap = computed(() => {
   const map = new Map<string, CalendarEvent[]>()
 
   // Get the visible hour range from time slots, but exclude hour 0 (12:00 AM)
-  const visibleHours = timeSlots.value.map(slot => slot.hour).filter(hour => hour !== 0)
-  const minVisibleHour = visibleHours.length > 0 ? Math.min(...visibleHours) : 13
-  const maxVisibleHour = visibleHours.length > 0 ? Math.max(...visibleHours) : 23
+  const visibleHours = timeSlots.value
+    .map((slot) => slot.hour)
+    .filter((hour) => hour !== 0)
+  const minVisibleHour =
+    visibleHours.length > 0 ? Math.min(...visibleHours) : 13
+  const maxVisibleHour =
+    visibleHours.length > 0 ? Math.max(...visibleHours) : 23
 
   events.value.forEach((event) => {
     const eventStart = new Date(event.startTime)
@@ -88,7 +92,13 @@ const eventMap = computed(() => {
     )
 
     // Only add events that fall within the visible time range (excluding hour 0)
-    if (dayIndex >= 0 && dayIndex < 7 && eventHour >= minVisibleHour && eventHour <= maxVisibleHour && eventHour !== 0) {
+    if (
+      dayIndex >= 0 &&
+      dayIndex < 7 &&
+      eventHour >= minVisibleHour &&
+      eventHour <= maxVisibleHour &&
+      eventHour !== 0
+    ) {
       const key = `${dayIndex}-${eventHour}`
       if (!map.has(key)) {
         map.set(key, [])


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
Filter events to visible hour range
Exclude 12:00 AM only in afternoon view
Guard against empty time slots
Clear style cache on time slot changes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  events["Events list"] -- "iterate" --> filter["Filter by visible hours"]
  timeSlots["Time slots"] -- "derive min/max hours" --> filter
  currentHour["Current hour info"] -- "determine window" --> filter
  filter -- "build keys day-hour" --> eventMap["Precomputed event map"]
  events+timeSlots["Events or time slots change"] -- "clear" --> cache["Style cache"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WeeklyCalendarView.vue</strong><dd><code>Constrain events to visible hours; adjust cache invalidation</code></dd></summary>
<hr>

edge-apps/google-calendar/src/components/WeeklyCalendarView.vue

<ul><li>Guard event map when no time slots.<br> <li> Compute visible hour range from time slots.<br> <li> Include events only within visible range; exclude hour 0 in afternoon.<br> <li> Clear style cache when events or time slots change.</ul>


</details>


  </td>
  <td><a href="https://github.com/Screenly/Playground/pull/369/files#diff-30e9f503212183846bf391ff4eaa9eb00917eebd957f89ff5274bbabad9119b5">+29/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

