### PR TITLE
fix: only display events in monthly view that occur until end of current day

### DIFF
--- a/edge-apps/google-calendar/src/components/MonthlyCalendarView.vue
+++ b/edge-apps/google-calendar/src/components/MonthlyCalendarView.vue
@@ -18,7 +18,7 @@
         </div>
       </div>
       <div v-if="filteredEvents.length === 0" class="no-events">
-        No events scheduled for next 24 hours
+        No events scheduled for today
       </div>
     </div>
   </div>
@@ -42,10 +42,11 @@ const events = computed(() => calendarStore.events)
 const locale = computed(() => calendarStore.locale)
 
 const filterAndFormatEvents = async () => {
-  // Filter events for next 24 hours
+  // Filter events for current day only
   const now = new Date()
   const tomorrow = new Date(now)
-  tomorrow.setHours(now.getHours() + 24)
+  tomorrow.setDate(now.getDate() + 1)
+  tomorrow.setHours(0, 0, 0, 0)
 
   const upcomingEvents = events.value.filter((event: CalendarEvent) => {
     const eventStart = new Date(event.startTime)


### PR DESCRIPTION
### **User description**
### Data

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b48d34a6-4443-4265-ae8d-527bc84339cd" />

### Before

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e98d7b08-0c80-4393-8a98-97710360cacd" />

### After

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2082ab32-505c-4fbd-a984-998df03c3175" />


___

### **PR Type**
Bug fix


___

### **Description**
Limit monthly view to today's events
Adjust time window to midnight boundary
Update empty state message text
Preserve event formatting and sorting


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MonthlyCalendarView.vue"] -- "Filter window logic" --> B["Use today's end (midnight)"]
  A -- "UI text" --> C["Empty state message updated"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MonthlyCalendarView.vue</strong><dd><code>Restrict events to current day and update copy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

edge-apps/google-calendar/src/components/MonthlyCalendarView.vue

<ul><li>Change filter to include only events starting today.<br> <li> Compute next day at midnight instead of now+24h.<br> <li> Update empty-state copy to "No events scheduled for today".</ul>


</details>


  </td>
  <td><a href="https://github.com/Screenly/Playground/pull/385/files#diff-4a7ca38f5a46664d37844afc129f43ea90f1b5b79831994a8d6b0a40d34842a4">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

