### PR TITLE
feat: add a section in monthly view that shows tomorrow's events

### DIFF
--- a/edge-apps/google-calendar/src/assets/monthly-calendar-view.scss
+++ b/edge-apps/google-calendar/src/assets/monthly-calendar-view.scss
@@ -69,9 +69,11 @@
         font-size: 0.6rem * $multiplier;
 
         @if $orientation == 'portrait' {
-          margin-bottom: 1rem * $multiplier;
+          margin-top: 1rem * $multiplier;
+          margin-bottom: 0.5rem * $multiplier;
         } @else {
-          margin-bottom: 0.75rem * $multiplier;
+          margin-top: 1rem * $multiplier;
+          margin-bottom: 0.5rem * $multiplier;
         }
       }
 
@@ -82,26 +84,26 @@
           .event-time {
             padding-top: 1.1rem * $multiplier;
             padding-bottom: 1.1rem * $multiplier;
-            padding-right: 3.75rem * $multiplier;
-            font-size: 1rem * $multiplier;
+            padding-right: 2rem * $multiplier;
+            font-size: 0.85rem * $multiplier;
             border-bottom-width: 0.01rem * $multiplier;
           }
 
           .event-title {
             padding-top: 1.1rem * $multiplier;
             padding-bottom: 1.1rem * $multiplier;
-            font-size: 1rem * $multiplier;
+            font-size: 0.85rem * $multiplier;
             border-bottom-width: 0.01rem * $multiplier;
 
             .event-dot {
-              font-size: 1.2rem * $multiplier;
+              font-size: 1rem * $multiplier;
               margin-right: 0.5rem * $multiplier;
             }
           }
         }
 
         .no-events {
-          font-size: 1rem * $multiplier;
+          font-size: 0.85rem * $multiplier;
           padding: 2rem * $multiplier;
         }
       }
@@ -110,7 +112,7 @@
 }
 
 @media screen and (min-width: 800px) and (max-width: 1279px) and (orientation: landscape) {
-  @include monthly-calendar-view('landscape', 1);
+  @include monthly-calendar-view('landscape', 0.75);
 }
 
 @media screen and (min-width: 480px) and (max-width: 719px) and (orientation: portrait) {
@@ -118,7 +120,7 @@
 }
 
 @media screen and (min-width: 1280px) and (max-width: 1919px) and (orientation: landscape) {
-  @include monthly-calendar-view('landscape', 1.5);
+  @include monthly-calendar-view('landscape', 1.3);
 }
 
 @media screen and (min-width: 720px) and (max-width: 1079px) and (orientation: portrait) {
@@ -126,7 +128,7 @@
 }
 
 @media screen and (min-width: 1920px) and (max-width: 3839px) and (orientation: landscape) {
-  @include monthly-calendar-view('landscape', 2.25);
+  @include monthly-calendar-view('landscape', 2);
 }
 
 @media screen and (min-width: 1080px) and (max-width: 2159px) and (orientation: portrait) {

--- a/edge-apps/google-calendar/src/components/MonthlyCalendarView.vue
+++ b/edge-apps/google-calendar/src/components/MonthlyCalendarView.vue
@@ -1,29 +1,3 @@
-<template>
-  <div class="MonthlyCalendarView primary-card">
-    <div class="events-heading">
-      <h1>{{ currentDayOfWeek }}</h1>
-    </div>
-    <div class="events-container">
-      <div
-        v-for="(event, index) in filteredEvents"
-        :key="index"
-        class="event-row"
-      >
-        <div class="event-time">
-          {{ formattedEventTimes[event.startTime] || '...' }}
-        </div>
-        <div class="event-title">
-          <span class="event-dot">•</span>
-          {{ event.title }}
-        </div>
-      </div>
-      <div v-if="filteredEvents.length === 0" class="no-events">
-        No events scheduled for next 24 hours
-      </div>
-    </div>
-  </div>
-</template>
-
 <script setup lang="ts">
 import { ref, watch, computed } from 'vue'
 import { useCalendarStore } from '@/stores/calendar'
@@ -34,7 +8,8 @@ const MAX_EVENTS = 7
 
 const calendarStore = useCalendarStore()
 
-const filteredEvents = ref<CalendarEvent[]>([])
+const todayEvents = ref<CalendarEvent[]>([])
+const tomorrowEvents = ref<CalendarEvent[]>([])
 const formattedEventTimes = ref<Record<string, string>>({})
 
 const currentDayOfWeek = computed(() => calendarStore.currentDayOfWeek)
@@ -42,26 +17,60 @@ const events = computed(() => calendarStore.events)
 const locale = computed(() => calendarStore.locale)
 
 const filterAndFormatEvents = async () => {
-  // Filter events for next 24 hours
+  // Filter events for today and tomorrow separately
   const now = new Date()
-  const tomorrow = new Date(now)
-  tomorrow.setHours(now.getHours() + 24)
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const todayEnd = new Date(todayStart)
+  todayEnd.setDate(todayStart.getDate() + 1)
 
-  const upcomingEvents = events.value.filter((event: CalendarEvent) => {
+  const tomorrowStart = new Date(todayStart)
+  tomorrowStart.setDate(todayStart.getDate() + 1)
+  const tomorrowEnd = new Date(tomorrowStart)
+  tomorrowEnd.setDate(tomorrowStart.getDate() + 1)
+
+  // Filter today's events
+  const todayEventsList = events.value.filter((event: CalendarEvent) => {
     const eventStart = new Date(event.startTime)
-    return eventStart >= now && eventStart < tomorrow
+    return eventStart >= now && eventStart < todayEnd
+  })
+
+  // Filter tomorrow's events
+  const tomorrowEventsList = events.value.filter((event: CalendarEvent) => {
+    const eventStart = new Date(event.startTime)
+    return eventStart >= tomorrowStart && eventStart < tomorrowEnd
   })
 
   // Sort events by start time
-  upcomingEvents.sort(
+  todayEventsList.sort(
     (a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime(),
   )
-  const limitedEvents = upcomingEvents.slice(0, MAX_EVENTS)
-  filteredEvents.value = limitedEvents
+  tomorrowEventsList.sort(
+    (a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime(),
+  )
+
+  // Distribute events to maintain total around MAX_EVENTS
+  let limitedTodayEvents: CalendarEvent[]
+  let limitedTomorrowEvents: CalendarEvent[]
+
+  if (todayEventsList.length >= MAX_EVENTS) {
+    // If today has 7+ events, show only today's events
+    limitedTodayEvents = todayEventsList.slice(0, MAX_EVENTS)
+    limitedTomorrowEvents = []
+  } else {
+    // Show all of today's events and fill remaining slots with tomorrow's events
+    limitedTodayEvents = todayEventsList
+    const remainingSlots = MAX_EVENTS - todayEventsList.length
+    limitedTomorrowEvents = tomorrowEventsList.slice(0, remainingSlots)
+  }
+
+  todayEvents.value = limitedTodayEvents
+  tomorrowEvents.value = limitedTomorrowEvents
 
   // Format times for all events
   const times: Record<string, string> = {}
-  for (const event of limitedEvents) {
+  const allEvents = [...limitedTodayEvents, ...limitedTomorrowEvents]
+
+  for (const event of allEvents) {
     try {
       const formattedTime = await getFormattedTime(
         new Date(event.startTime),
@@ -79,6 +88,47 @@ const filterAndFormatEvents = async () => {
 watch([events, locale], filterAndFormatEvents, { immediate: true })
 </script>
 
-<style scoped src="@/assets/monthly-calendar-view.scss">
-/* Styles imported from SCSS file */
-</style>
+<template>
+  <div class="MonthlyCalendarView primary-card">
+    <!-- Today's Events -->
+    <div class="events-heading">
+      <h1>{{ currentDayOfWeek }}</h1>
+    </div>
+    <div class="events-container">
+      <div v-for="(event, index) in todayEvents" :key="index" class="event-row">
+        <div class="event-time">
+          {{ formattedEventTimes[event.startTime] || '...' }}
+        </div>
+        <div class="event-title">
+          <span class="event-dot">•</span>
+          {{ event.title }}
+        </div>
+      </div>
+      <div v-if="todayEvents.length === 0" class="no-events">
+        No events scheduled for today
+      </div>
+    </div>
+
+    <!-- Tomorrow's Events -->
+    <div v-if="tomorrowEvents.length > 0" class="events-heading">
+      <h1>TOMORROW</h1>
+    </div>
+    <div v-if="tomorrowEvents.length > 0" class="events-container">
+      <div
+        v-for="(event, index) in tomorrowEvents"
+        :key="index"
+        class="event-row"
+      >
+        <div class="event-time">
+          {{ formattedEventTimes[event.startTime] || '...' }}
+        </div>
+        <div class="event-title">
+          <span class="event-dot">•</span>
+          {{ event.title }}
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped src="@/assets/monthly-calendar-view.scss"></style>

--- a/edge-apps/google-calendar/src/events.ts
+++ b/edge-apps/google-calendar/src/events.ts
@@ -37,11 +37,20 @@ const getDateRangeForViewMode = (viewMode: ViewMode) => {
     // For daily view, start at midnight in the target timezone
     startDate = todayInTimezone.toDate()
     endDate = todayInTimezone.add(1, 'day').toDate()
-  } else {
+  } else if (viewMode === VIEW_MODE.WEEKLY) {
     // For weekly view, show full week starting from Sunday in the target timezone
     const weekStart = todayInTimezone.startOf('week')
     startDate = weekStart.toDate()
     endDate = weekStart.add(7, 'days').toDate()
+  } else if (viewMode === VIEW_MODE.MONTHLY) {
+    // For monthly view, show full month starting from the first day of the month
+    const monthStart = todayInTimezone.startOf('month')
+    startDate = monthStart.toDate()
+    endDate = monthStart.add(1, 'month').toDate()
+  } else {
+    // Default to daily view
+    startDate = todayInTimezone.toDate()
+    endDate = todayInTimezone.add(1, 'day').toDate()
   }
 
   return { startDate, endDate }


### PR DESCRIPTION
Added a dynamic section for showing tomorrow's events because there are too much free space if there's not much to show.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/181da344-7eac-4568-be9b-fe2d7c97bd77" />
