### PR TITLE
chore: enable creation of Dependabot PRs for the Edge App template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,19 @@ updates:
   - package-ecosystem: "bun"
     directories:
       - "edge-apps/*"
-      - "edge-apps/.bun-create/edge-app-template"
     schedule:
       interval: "daily"
     groups:
       bun:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/edge-apps/.bun-create/edge-app-template"
+    schedule:
+      interval: "daily"
+    groups:
+      edge-app-template:
         patterns:
           - "*"
 


### PR DESCRIPTION
### **User description**
- Dependabot is not creating Dependabot PRs for the Edge App Template lately.
- This PR configures `dependabot.yml` so that relevant PRs can be created again.


___

### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Reconfigure Dependabot ecosystems and scopes

- Add npm updates for edge app template

- Remove template path from bun directories

- Keep daily schedules and grouping


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dependabot config"] -- "bun updates" --> B["edge-apps/*"]
  A -- "remove" --> C[".bun-create path from bun"]
  A -- "add npm updates" --> D["/edge-apps/.bun-create/edge-app-template"]
  A -- "pip updates" --> E["/edge-apps/queue-management-system/server"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot.yml</strong><dd><code>Add npm updates and adjust bun scopes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/dependabot.yml

<ul><li>Remove template path from bun directories.<br> <li> Add npm ecosystem for edge app template path.<br> <li> Configure daily schedule and grouping for npm.<br> <li> Retain existing bun and pip configurations.</ul>


</details>


  </td>
  <td><a href="https://github.com/Screenly/Playground/pull/402/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

