### PR TITLE
chore: update Cursor rules to accomodate Vue projects

### DIFF
--- a/.cursor/rules/edge-apps.mdc
+++ b/.cursor/rules/edge-apps.mdc
@@ -1,6 +1,4 @@
 ---
-description:
-globs:
 alwaysApply: true
 ---
 # Edge Apps In-Depth
@@ -11,6 +9,8 @@ As stated in [general.mdc](mdc:.cursor/rules/general.mdc), Edge Apps is a framew
 digital signage screens.
 
 ## Writing an Edge App from Scratch
+
+This rule applies to Edge Apps that are written in plain HTML, CSS, and JavaScript.
 
 - Create a directory inside the [edge-apps](mdc:edge-apps) directory.
 - That new directory should at least contain the following files:
@@ -57,9 +57,16 @@ document.addEventListener('DOMContentLoaded', async () => {
 
 `screenly.signalReadyForRendering()` tells the device that the Edge App is ready to be displayed on the screen. See this [documentation about the ready signal](mdc:https://developer.screenly.io/edge-apps/#ready-signal) for details.
 
-## Edge Cases
+## Creating a Vue-based Edge App via the template
 
-- You can split your `main.js` into multiple files and use `import` and `export` statements.
-- You can also opt for using a build system and other web frameworks, but it could get tricky. See
-  the [Google Calendar Edge App's implementation](mdc:edge-apps/google-calendar) for reference. It uses React and Webpack for the source code.
-- We encourage starting with the basic HTML/CSS/JavaScript template if the Edge App is not that complex. Otherwise, you can make use of established front-end frameworks like React.
+To create a new project, run the following command:
+
+```bash
+cd edge-apps/
+bun create --no-git edge-app-template <edge-app-name>
+```
+
+You have to be inside the `edge-apps` directory to run this command successfully.
+This will create a new Edge App with the name `<edge-app-name>` in the `edge-apps` directory.
+
+These kind of Edge Apps are written in Vue and TypeScript. All of those projects use Bun for runtime and Vite for build system.

--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -1,11 +1,9 @@
 ---
-description:
-globs:
 alwaysApply: true
 ---
 # General
 
-- You are a senior software engineer writing Edge Apps for Screenly.
+- You are a principal software engineer writing Edge Apps for Screenly.
 
 # Edge Apps
 

--- a/.cursor/rules/scss.mdc
+++ b/.cursor/rules/scss.mdc
@@ -1,12 +1,12 @@
 ---
 alwaysApply: true
 ---
-### CSS
 
+### SCSS
+
+- All Edge Apps written in Vue and TypeScript use SCSS for styling.
+- While it's okay to use CSS, you should prefer SCSS whenever possible.
 - Always use `rem` instead of `px` when specifying values like font size, margins, paddings, etc.
 - Avoid using `!important` as it breaks the natural cascading behavior of CSS. Instead, use more specific selectors or leverage CSS custom properties (variables) for values that need to be overridden.
 - Use CSS custom properties (variables) for theme values, colors, and other design tokens that need to be overridden.
-- Do not add code comments to CSS code unless it's not obvious what the code does.
-- This project uses [Super Linter](mdc:https:/github.com/github/super-linter) for linting.
-  - Stylelint is used for linting CSS files.
-- Use Stylelint's rules (https://stylelint.io/user-guide/rules) as guide when generate code.
+- Do not add code comments to SCSS code unless it's not obvious what the code does.


### PR DESCRIPTION
- Updates the general rule for agents to assume the role of a principal software engineer, which heavily relies on strategic thinking
- Added a new rule for Vue-based Edge Apps