### PR TITLE
docs: add git commit guidelines to general rules

### DIFF
--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -35,4 +35,5 @@ alwaysApply: true
   
   When committing staged changes in Git:
   - Use Conventional Commits for writing commit messages. Check https://www.conventionalcommits.org/ for details.
+  - Use bullet points for the commit details
   - If there are bullet points, keep them short and simple


### PR DESCRIPTION
### **User description**
Add a new section about committing changes that enforces Conventional Commits format


___

### **PR Type**
Documentation


___

### **Description**
- Add "Committing Changes" guidelines section

- Enforce Conventional Commits usage

- Recommend concise bullet points


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Rules["General rules doc"] -- "add section" --> CommitGuides["Committing Changes"]
  CommitGuides -- "mandate" --> ConvCommits["Conventional Commits"]
  CommitGuides -- "style tip" --> Bullets["Keep bullets concise"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>general.mdc</strong><dd><code>Add commit message guidelines section</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.cursor/rules/general.mdc

<ul><li>Add "Committing Changes" section to rules.<br> <li> Instruct to use Conventional Commits.<br> <li> Advise concise bullet points in commits.</ul>


</details>


  </td>
  <td><a href="https://github.com/Screenly/Playground/pull/476/files#diff-882cff703a812001430358c6aae2394d0d174288c06cf853ea630088c9b3a493">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

