### PR TITLE
feat(edge-apps-library): add optional latitude and longitude parameters to getTimeZone

### DIFF
--- a/edge-apps/edge-apps-library/src/utils/locale.test.ts
+++ b/edge-apps/edge-apps-library/src/utils/locale.test.ts
@@ -2,23 +2,6 @@ import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
 import { getTimeZone, formatCoordinates, getLocale } from './locale'
 import { setupScreenlyMock, resetScreenlyMock } from '../test/mock'
 
-// Test coordinates
-const COORDS = {
-  LA: [37.3861, -122.0839] as [number, number],
-  LONDON: [51.5074, -0.1278] as [number, number],
-  TOKYO: [35.6762, 139.6503] as [number, number],
-}
-
-// Helper to test coordinate-to-timezone mapping
-async function testCoordinateTimezone(
-  coords: [number, number],
-  expectedTimezone: string,
-) {
-  setupScreenlyMock({ coordinates: coords })
-  const timezone = await getTimeZone()
-  expect(timezone).toBe(expectedTimezone)
-}
-
 // eslint-disable-next-line max-lines-per-function
 describe('locale utilities', () => {
   beforeEach(() => {
@@ -30,19 +13,41 @@ describe('locale utilities', () => {
   })
 
   describe('getTimeZone', () => {
-    test('should return timezone for coordinates', () =>
-      testCoordinateTimezone(COORDS.LA, 'America/Los_Angeles'))
+    test('should return timezone for coordinates', async () => {
+      setupScreenlyMock({
+        coordinates: [37.3861, -122.0839], // Mountain View, CA
+      })
 
-    test('should return timezone for London coordinates', () =>
-      testCoordinateTimezone(COORDS.LONDON, 'Europe/London'))
+      const timezone = await getTimeZone()
+      expect(timezone).toBe('America/Los_Angeles')
+    })
 
-    test('should return timezone for Tokyo coordinates', () =>
-      testCoordinateTimezone(COORDS.TOKYO, 'Asia/Tokyo'))
+    test('should return timezone for London coordinates', async () => {
+      setupScreenlyMock({
+        coordinates: [51.5074, -0.1278], // London, UK
+      })
+
+      const timezone = await getTimeZone()
+      expect(timezone).toBe('Europe/London')
+    })
+
+    test('should return timezone for Tokyo coordinates', async () => {
+      setupScreenlyMock({
+        coordinates: [35.6762, 139.6503], // Tokyo, Japan
+      })
+
+      const timezone = await getTimeZone()
+      expect(timezone).toBe('Asia/Tokyo')
+    })
 
     test('should use valid override_timezone setting', async () => {
       setupScreenlyMock(
-        { coordinates: COORDS.LA },
-        { override_timezone: 'Europe/Paris' },
+        {
+          coordinates: [37.3861, -122.0839],
+        },
+        {
+          override_timezone: 'Europe/Paris',
+        },
       )
 
       const timezone = await getTimeZone()
@@ -51,8 +56,12 @@ describe('locale utilities', () => {
 
     test('should fallback to GPS detection for invalid override_timezone', async () => {
       setupScreenlyMock(
-        { coordinates: COORDS.LONDON },
-        { override_timezone: 'Invalid/Timezone' },
+        {
+          coordinates: [51.5074, -0.1278],
+        },
+        {
+          override_timezone: 'Invalid/Timezone',
+        },
       )
 
       const timezone = await getTimeZone()
@@ -60,40 +69,18 @@ describe('locale utilities', () => {
     })
 
     test('should fallback to UTC when coordinates are missing', async () => {
-      setupScreenlyMock({ coordinates: undefined })
+      setupScreenlyMock({
+        coordinates: undefined,
+      })
 
       const timezone = await getTimeZone()
       expect(timezone).toBe('UTC')
-    })
-
-    test('should use provided coordinates instead of metadata', async () => {
-      setupScreenlyMock({ coordinates: COORDS.LA })
-
-      const timezone = await getTimeZone(...COORDS.TOKYO)
-      expect(timezone).toBe('Asia/Tokyo')
-    })
-
-    test('should respect override_timezone even with provided coordinates', async () => {
-      setupScreenlyMock(
-        { coordinates: COORDS.LA },
-        { override_timezone: 'Europe/Paris' },
-      )
-
-      const timezone = await getTimeZone(...COORDS.TOKYO)
-      expect(timezone).toBe('Europe/Paris')
-    })
-
-    test('should use metadata when only one coordinate provided', async () => {
-      setupScreenlyMock({ coordinates: COORDS.LONDON })
-
-      const timezone = await getTimeZone(COORDS.TOKYO[0], undefined)
-      expect(timezone).toBe('Europe/London')
     })
   })
 
   describe('formatCoordinates', () => {
     test('should format positive coordinates correctly', () => {
-      const formatted = formatCoordinates(COORDS.LA)
+      const formatted = formatCoordinates([37.3861, -122.0839])
       expect(formatted).toBe('37.3861° N, 122.0839° W')
     })
 
@@ -103,7 +90,7 @@ describe('locale utilities', () => {
     })
 
     test('should format coordinates with proper precision', () => {
-      const formatted = formatCoordinates(COORDS.LONDON)
+      const formatted = formatCoordinates([51.5074, -0.1278]) // London
       expect(formatted).toBe('51.5074° N, 0.1278° W')
     })
 
@@ -115,11 +102,16 @@ describe('locale utilities', () => {
     })
   })
 
+  // eslint-disable-next-line max-lines-per-function
   describe('getLocale', () => {
     test('should normalize single underscore in override_locale', async () => {
       setupScreenlyMock(
-        { coordinates: COORDS.LA },
-        { override_locale: 'en_US' },
+        {
+          coordinates: [37.3861, -122.0839],
+        },
+        {
+          override_locale: 'en_US',
+        },
       )
 
       const locale = await getLocale()
@@ -128,8 +120,12 @@ describe('locale utilities', () => {
 
     test('should normalize multiple underscores in override_locale', async () => {
       setupScreenlyMock(
-        { coordinates: COORDS.LA },
-        { override_locale: 'de_DE' },
+        {
+          coordinates: [37.3861, -122.0839],
+        },
+        {
+          override_locale: 'de_DE',
+        },
       )
 
       const locale = await getLocale()
@@ -138,41 +134,61 @@ describe('locale utilities', () => {
 
     test('should fallback to GPS detection for invalid override_locale', async () => {
       setupScreenlyMock(
-        { coordinates: COORDS.TOKYO },
-        { override_locale: 'invalid_locale_xyz' },
+        {
+          coordinates: [35.6762, 139.6503], // Tokyo, Japan
+        },
+        {
+          override_locale: 'invalid_locale_xyz',
+        },
       )
 
       const locale = await getLocale()
+      // Should fallback to GPS-based locale detection (ja for Japan)
       expect(locale.startsWith('ja')).toBe(true)
     })
 
     test('should reject malformed locale with trailing hyphen', async () => {
       setupScreenlyMock(
-        { coordinates: COORDS.TOKYO },
-        { override_locale: 'en-' },
+        {
+          coordinates: [35.6762, 139.6503],
+        },
+        {
+          override_locale: 'en-',
+        },
       )
 
       const locale = await getLocale()
+      // Should fallback to GPS-based locale detection
       expect(locale.startsWith('ja')).toBe(true)
     })
 
     test('should reject malformed locale where region code is invalid', async () => {
       setupScreenlyMock(
-        { coordinates: COORDS.TOKYO },
-        { override_locale: 'en-INVALID' },
+        {
+          coordinates: [35.6762, 139.6503],
+        },
+        {
+          override_locale: 'en-INVALID',
+        },
       )
 
       const locale = await getLocale()
+      // Should fallback to GPS-based locale detection (not use 'en')
       expect(locale.startsWith('ja')).toBe(true)
     })
 
     test('should reject locale with underscores and invalid parts', async () => {
       setupScreenlyMock(
-        { coordinates: COORDS.TOKYO },
-        { override_locale: 'en_US_INVALID_EXTRA' },
+        {
+          coordinates: [35.6762, 139.6503],
+        },
+        {
+          override_locale: 'en_US_INVALID_EXTRA',
+        },
       )
 
       const locale = await getLocale()
+      // Should fallback to GPS-based locale detection
       expect(locale.startsWith('ja')).toBe(true)
     })
   })

--- a/edge-apps/edge-apps-library/src/utils/locale.test.ts
+++ b/edge-apps/edge-apps-library/src/utils/locale.test.ts
@@ -2,6 +2,23 @@ import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
 import { getTimeZone, formatCoordinates, getLocale } from './locale'
 import { setupScreenlyMock, resetScreenlyMock } from '../test/mock'
 
+// Test coordinates
+const COORDS = {
+  LA: [37.3861, -122.0839] as [number, number],
+  LONDON: [51.5074, -0.1278] as [number, number],
+  TOKYO: [35.6762, 139.6503] as [number, number],
+}
+
+// Helper to test coordinate-to-timezone mapping
+async function testCoordinateTimezone(
+  coords: [number, number],
+  expectedTimezone: string,
+) {
+  setupScreenlyMock({ coordinates: coords })
+  const timezone = await getTimeZone()
+  expect(timezone).toBe(expectedTimezone)
+}
+
 // eslint-disable-next-line max-lines-per-function
 describe('locale utilities', () => {
   beforeEach(() => {
@@ -13,41 +30,19 @@ describe('locale utilities', () => {
   })
 
   describe('getTimeZone', () => {
-    test('should return timezone for coordinates', async () => {
-      setupScreenlyMock({
-        coordinates: [37.3861, -122.0839], // Mountain View, CA
-      })
+    test('should return timezone for coordinates', () =>
+      testCoordinateTimezone(COORDS.LA, 'America/Los_Angeles'))
 
-      const timezone = await getTimeZone()
-      expect(timezone).toBe('America/Los_Angeles')
-    })
+    test('should return timezone for London coordinates', () =>
+      testCoordinateTimezone(COORDS.LONDON, 'Europe/London'))
 
-    test('should return timezone for London coordinates', async () => {
-      setupScreenlyMock({
-        coordinates: [51.5074, -0.1278], // London, UK
-      })
-
-      const timezone = await getTimeZone()
-      expect(timezone).toBe('Europe/London')
-    })
-
-    test('should return timezone for Tokyo coordinates', async () => {
-      setupScreenlyMock({
-        coordinates: [35.6762, 139.6503], // Tokyo, Japan
-      })
-
-      const timezone = await getTimeZone()
-      expect(timezone).toBe('Asia/Tokyo')
-    })
+    test('should return timezone for Tokyo coordinates', () =>
+      testCoordinateTimezone(COORDS.TOKYO, 'Asia/Tokyo'))
 
     test('should use valid override_timezone setting', async () => {
       setupScreenlyMock(
-        {
-          coordinates: [37.3861, -122.0839],
-        },
-        {
-          override_timezone: 'Europe/Paris',
-        },
+        { coordinates: COORDS.LA },
+        { override_timezone: 'Europe/Paris' },
       )
 
       const timezone = await getTimeZone()
@@ -56,12 +51,8 @@ describe('locale utilities', () => {
 
     test('should fallback to GPS detection for invalid override_timezone', async () => {
       setupScreenlyMock(
-        {
-          coordinates: [51.5074, -0.1278],
-        },
-        {
-          override_timezone: 'Invalid/Timezone',
-        },
+        { coordinates: COORDS.LONDON },
+        { override_timezone: 'Invalid/Timezone' },
       )
 
       const timezone = await getTimeZone()
@@ -69,18 +60,40 @@ describe('locale utilities', () => {
     })
 
     test('should fallback to UTC when coordinates are missing', async () => {
-      setupScreenlyMock({
-        coordinates: undefined,
-      })
+      setupScreenlyMock({ coordinates: undefined })
 
       const timezone = await getTimeZone()
       expect(timezone).toBe('UTC')
+    })
+
+    test('should use provided coordinates instead of metadata', async () => {
+      setupScreenlyMock({ coordinates: COORDS.LA })
+
+      const timezone = await getTimeZone(...COORDS.TOKYO)
+      expect(timezone).toBe('Asia/Tokyo')
+    })
+
+    test('should respect override_timezone even with provided coordinates', async () => {
+      setupScreenlyMock(
+        { coordinates: COORDS.LA },
+        { override_timezone: 'Europe/Paris' },
+      )
+
+      const timezone = await getTimeZone(...COORDS.TOKYO)
+      expect(timezone).toBe('Europe/Paris')
+    })
+
+    test('should use metadata when only one coordinate provided', async () => {
+      setupScreenlyMock({ coordinates: COORDS.LONDON })
+
+      const timezone = await getTimeZone(COORDS.TOKYO[0], undefined)
+      expect(timezone).toBe('Europe/London')
     })
   })
 
   describe('formatCoordinates', () => {
     test('should format positive coordinates correctly', () => {
-      const formatted = formatCoordinates([37.3861, -122.0839])
+      const formatted = formatCoordinates(COORDS.LA)
       expect(formatted).toBe('37.3861° N, 122.0839° W')
     })
 
@@ -90,7 +103,7 @@ describe('locale utilities', () => {
     })
 
     test('should format coordinates with proper precision', () => {
-      const formatted = formatCoordinates([51.5074, -0.1278]) // London
+      const formatted = formatCoordinates(COORDS.LONDON)
       expect(formatted).toBe('51.5074° N, 0.1278° W')
     })
 
@@ -102,16 +115,11 @@ describe('locale utilities', () => {
     })
   })
 
-  // eslint-disable-next-line max-lines-per-function
   describe('getLocale', () => {
     test('should normalize single underscore in override_locale', async () => {
       setupScreenlyMock(
-        {
-          coordinates: [37.3861, -122.0839],
-        },
-        {
-          override_locale: 'en_US',
-        },
+        { coordinates: COORDS.LA },
+        { override_locale: 'en_US' },
       )
 
       const locale = await getLocale()
@@ -120,12 +128,8 @@ describe('locale utilities', () => {
 
     test('should normalize multiple underscores in override_locale', async () => {
       setupScreenlyMock(
-        {
-          coordinates: [37.3861, -122.0839],
-        },
-        {
-          override_locale: 'de_DE',
-        },
+        { coordinates: COORDS.LA },
+        { override_locale: 'de_DE' },
       )
 
       const locale = await getLocale()
@@ -134,61 +138,41 @@ describe('locale utilities', () => {
 
     test('should fallback to GPS detection for invalid override_locale', async () => {
       setupScreenlyMock(
-        {
-          coordinates: [35.6762, 139.6503], // Tokyo, Japan
-        },
-        {
-          override_locale: 'invalid_locale_xyz',
-        },
+        { coordinates: COORDS.TOKYO },
+        { override_locale: 'invalid_locale_xyz' },
       )
 
       const locale = await getLocale()
-      // Should fallback to GPS-based locale detection (ja for Japan)
       expect(locale.startsWith('ja')).toBe(true)
     })
 
     test('should reject malformed locale with trailing hyphen', async () => {
       setupScreenlyMock(
-        {
-          coordinates: [35.6762, 139.6503],
-        },
-        {
-          override_locale: 'en-',
-        },
+        { coordinates: COORDS.TOKYO },
+        { override_locale: 'en-' },
       )
 
       const locale = await getLocale()
-      // Should fallback to GPS-based locale detection
       expect(locale.startsWith('ja')).toBe(true)
     })
 
     test('should reject malformed locale where region code is invalid', async () => {
       setupScreenlyMock(
-        {
-          coordinates: [35.6762, 139.6503],
-        },
-        {
-          override_locale: 'en-INVALID',
-        },
+        { coordinates: COORDS.TOKYO },
+        { override_locale: 'en-INVALID' },
       )
 
       const locale = await getLocale()
-      // Should fallback to GPS-based locale detection (not use 'en')
       expect(locale.startsWith('ja')).toBe(true)
     })
 
     test('should reject locale with underscores and invalid parts', async () => {
       setupScreenlyMock(
-        {
-          coordinates: [35.6762, 139.6503],
-        },
-        {
-          override_locale: 'en_US_INVALID_EXTRA',
-        },
+        { coordinates: COORDS.TOKYO },
+        { override_locale: 'en_US_INVALID_EXTRA' },
       )
 
       const locale = await getLocale()
-      // Should fallback to GPS-based locale detection
       expect(locale.startsWith('ja')).toBe(true)
     })
   })

--- a/edge-apps/edge-apps-library/src/utils/locale.ts
+++ b/edge-apps/edge-apps-library/src/utils/locale.ts
@@ -65,8 +65,14 @@ function isValidLocale(locale: string): boolean {
 /**
  * Resolve timezone configuration with fallback chain
  * Fallback order: override setting (validated) → GPS-based detection → 'UTC'
+ *
+ * @param latitude - Optional latitude coordinate (overrides metadata coordinates)
+ * @param longitude - Optional longitude coordinate (overrides metadata coordinates)
  */
-export async function getTimeZone(): Promise<string> {
+export async function getTimeZone(
+  latitude?: number,
+  longitude?: number,
+): Promise<string> {
   // Priority 1: Use override setting if provided and valid
   const overrideTimezone = getSettingWithDefault<string>(
     'override_timezone',
@@ -83,8 +89,12 @@ export async function getTimeZone(): Promise<string> {
   }
 
   try {
-    const [latitude, longitude] = getMetadata().coordinates
-    return tzlookup(latitude, longitude)
+    // Use provided coordinates or fall back to metadata coordinates
+    const [lat, lng] =
+      latitude !== undefined && longitude !== undefined
+        ? [latitude, longitude]
+        : getMetadata().coordinates
+    return tzlookup(lat, lng)
   } catch (error) {
     console.warn('Failed to get timezone from coordinates, using UTC:', error)
     return 'UTC'


### PR DESCRIPTION
### **User description**
## Summary

- Add optional `latitude` and `longitude` parameters to `getTimeZone()` function
- Allows callers to provide custom coordinates instead of always relying on metadata coordinates
- Maintains backward compatibility (parameters are optional)
- Provides flexibility for testing and use cases where coordinates are known in advance

## Changes

- Updated `getTimeZone()` signature to accept optional `latitude?: number, longitude?: number` parameters
- Added JSDoc documentation for the new parameters
- Modified coordinate resolution logic to prioritize provided parameters over metadata coordinates


___

### **PR Type**
Enhancement


___

### **Description**
- Add optional coordinates to `getTimeZone`

- Prefer explicit params over metadata coordinates

- Keep override/UTC fallback behavior unchanged


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Caller"] 
  B["getTimeZone(latitude?, longitude?)"]
  C["override_timezone setting"]
  D["Provided coordinates"]
  E["Metadata coordinates"]
  F["tzlookup()"]
  G["UTC fallback"]

  A -- "calls" --> B
  B -- "check override" --> C
  B -- "if no valid override" --> D
  D -- "else fallback" --> E
  D -- "resolve coords" --> F
  E -- "resolve coords" --> F
  B -- "on error" --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>locale.ts</strong><dd><code>Allow getTimeZone to accept custom coordinates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

edge-apps/edge-apps-library/src/utils/locale.ts

<ul><li>Add <code>latitude?</code> and <code>longitude?</code> parameters<br> <li> Document new parameters in JSDoc<br> <li> Use params when provided, else metadata<br> <li> Pass resolved coords into <code>tzlookup</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Screenly/Playground/pull/671/files#diff-e290b919972a6bb36899b845525124b43475ccea5aac7efa9fcfe1d6d04b3449">+13/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

