### PR TITLE
fix(simple-message-app): prevent text overflow for long unbroken strings

### DIFF
--- a/edge-apps/simple-message-app/src/css/style.css
+++ b/edge-apps/simple-message-app/src/css/style.css
@@ -68,6 +68,7 @@ app-header {
   line-height: normal;
   color: white;
   white-space: pre-wrap;
+  overflow-wrap: break-word;
 }
 
 #date-badge {
@@ -122,6 +123,7 @@ app-header {
   line-height: 1.333;
   color: white;
   white-space: pre-wrap;
+  overflow-wrap: break-word;
 }
 
 @media (orientation: portrait) {


### PR DESCRIPTION
### **User description**
Adds `overflow-wrap: break-word` to `#message-header` and `#message-body` to prevent text without spaces (e.g., slash-separated strings) from overflowing outside their containers.


Now
<img width="1878" height="985" alt="image" src="https://github.com/user-attachments/assets/8d313833-223d-4136-8947-341a6bb37bb9" />


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent long strings from overflowing

- Add word wrapping to message text

- Apply fix to header and body


___

### Diagram Walkthrough


```mermaid
flowchart LR
  css["style.css text containers"]
  header["#message-header"]
  body["#message-body"]
  wrap["overflow-wrap: break-word"]
  css -- "updates" --> header
  css -- "updates" --> body
  header -- "adds" --> wrap
  body -- "adds" --> wrap
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>style.css</strong><dd><code>Add wrapping for long message text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

edge-apps/simple-message-app/src/css/style.css

<ul><li>Add <code>overflow-wrap: break-word</code> to <code>#message-header</code><br> <li> Add <code>overflow-wrap: break-word</code> to <code>#message-body</code><br> <li> Prevent long unbroken text from overflowing containers</ul>


</details>


  </td>
  <td><a href="https://github.com/Screenly/Playground/pull/786/files#diff-45b0c565c60cc78cd7b7810dd6f2627dd676afcfe3abede4638d82309ea48967">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

