### PR TITLE
fix(powerbi): improve error handling for embed token retrieval

### DIFF
--- a/edge-apps/powerbi/static/js/main.js
+++ b/edge-apps/powerbi/static/js/main.js
@@ -77,19 +77,9 @@
         detailedMessage = `Failed to get embed token.`
       }
 
-      showError({
-        detailedMessage: detailedMessage,
-        technicalDetails: {
-          errorInfo: [
-            {
-              key: 'status',
-              value: response.status,
-            },
-          ],
-        },
-      })
-
-      throw new Error(detailedMessage)
+      const error = new Error(detailedMessage)
+      error.status = response.status
+      throw error
     }
 
     const { token } = await response.json()
@@ -110,12 +100,10 @@
         currentErrorStep = 0
       } catch {
         nextTimeout = Math.min(
-          initErrorDelaySec * Math.pow(2, currentErrorStep),
-          nextTimeout,
+          initErrorDelaySec *
+            Math.pow(2, Math.min(currentErrorStep, maxErrorStep)),
+          tokenRefreshInterval,
         )
-        if (currentErrorStep >= maxErrorStep) {
-          return
-        }
         currentErrorStep += 1
       }
       setTimeout(run, nextTimeout * 1000)
@@ -129,11 +117,24 @@
     const embedUrl = screenly.settings.embed_url
     const resourceType = getEmbedTypeFromUrl(embedUrl)
 
+    let initialToken
+    try {
+      initialToken = await getEmbedToken()
+    } catch (error) {
+      showError({
+        detailedMessage: error.message,
+        technicalDetails: {
+          errorInfo: [{ key: 'status', value: error.status }],
+        },
+      })
+      throw error
+    }
+
     const report = window.powerbi.embed(
       document.getElementById('embed-container'),
       {
         embedUrl: embedUrl,
-        accessToken: await getEmbedToken(),
+        accessToken: initialToken,
         type: resourceType,
         tokenType: models.TokenType.Embed,
         permissions: models.Permissions.All,


### PR DESCRIPTION
### **User description**
Fixes [T10507](https://phorge.chameleon-jazz.ts.net/T10507). Customer's Power BI capacity is paused outside business hours; players showed "Unable to load report" and stayed stuck until reboot.

Two surgical changes to `static/js/main.js`:                                                                                                           
  - `initTokenRefreshLoop` no longer gives up after 7 errors — caps the backoff exponent at `maxErrorStep` so the loop keeps retrying every refresh interval forever.                                                    
  - `getEmbedToken` no longer renders the error UI itself. The initial-load path in `initializePowerBI` shows the error template; background refresh failures stay silent and leave the rendered iframe in place.


___

### **PR Type**
Bug fix


___

### **Description**
- Preserve Power BI token refresh retries

- Move error UI handling upstream

- Show initial load status details


___

### Diagram Walkthrough


```mermaid
flowchart LR
  token["getEmbedToken throws enriched error"]
  init["initializePowerBI handles initial fetch failure"]
  refresh["Refresh loop retries with capped backoff"]
  iframe["Existing embedded report stays visible"]

  token -- "caught during startup" --> init
  token -- "caught during refresh" --> refresh
  refresh -- "avoids replacing UI" --> iframe
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.js</strong><dd><code>Refine Power BI token error flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

edge-apps/powerbi/static/js/main.js

<ul><li>Stop rendering error UI inside <code>getEmbedToken</code><br> <li> Attach HTTP <code>status</code> to thrown token errors<br> <li> Handle initial token failures in <code>initializePowerBI</code><br> <li> Keep refresh retries running with capped backoff</ul>


</details>


  </td>
  <td><a href="https://github.com/Screenly/Playground/pull/792/files#diff-7a4f3874ad5379179145c50bdfa72fed6761afd752e3d9a7b81423d06b19fe78">+20/-19</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

