### PR TITLE
chore(workflows): use reusable actions for initialize and update

### DIFF
--- a/.github/workflows/initialize-app.yml
+++ b/.github/workflows/initialize-app.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           ref: master
 
-      - uses: Screenly/edge-apps-actions/initialize@feat/add-path-input
+      - uses: Screenly/edge-apps-actions/initialize@v1
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN }}
           edge_app_name: ${{ inputs.edge_app_name }}

--- a/.github/workflows/initialize-app.yml
+++ b/.github/workflows/initialize-app.yml
@@ -22,21 +22,6 @@ on:
         description: 'Display title of the edge app (used in instance.yml)'
         required: true
 
-      build_system:
-        description: 'Build system for the Edge App'
-        required: true
-        default: 'vanilla'
-        type: choice
-        options:
-          - vanilla
-          - bun
-
-      deploy_from_dist:
-        description: "Deploy from the dist folder. If unchecked, deploy from app's root folder."
-        required: true
-        default: true
-        type: boolean
-
 run-name: Initializing ${{ inputs.edge_app_name }} in ${{ inputs.environment }}
 
 
@@ -46,12 +31,6 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
     environment: ${{ inputs.environment }}
-    env:
-      API_BASE_URL: ${{ inputs.environment == 'stage' && 'https://api.screenlyappstage.com' || 'https://api.screenlyapp.com' }}
-      APP_NAME: ${{ inputs.edge_app_name }}
-      APP_PATH: edge-apps/${{ inputs.edge_app_name }}
-      SCREENLY_API_TOKEN: ${{ secrets.SCREENLY_API_TOKEN }}
-      MANIFEST_FILE_NAME: ${{ inputs.environment == 'stage' && 'screenly_qc.yml' || 'screenly.yml' }}
 
     steps:
       - name: ⬇️ Checkout Repository
@@ -59,53 +38,10 @@ jobs:
         with:
           ref: master
 
-      - name: 🛠 Install Bun (React/Vue only)
-        if: ${{ inputs.build_system == 'bun' }}
-        uses: oven-sh/setup-bun@v2
+      - uses: Screenly/edge-apps-actions/initialize@feat/add-path-input
         with:
-          bun-version: 1.2.2
-
-      - name: 🛠 Setup and Build Bun App
-        if: ${{ inputs.build_system == 'bun' }}
-        working-directory: ${{ env.APP_PATH }}
-        run: |
-          bun install
-          bun run build
-
-      - name: 🔄 Modify APP_PATH based on app type
-        run: |
-          if [ "${{ inputs.build_system }}" = "bun" ] && [ "${{ inputs.deploy_from_dist }}" = "true" ]; then
-            echo "APP_PATH=${{ env.APP_PATH }}/dist" >> "$GITHUB_ENV"
-          fi
-
-      - name: 🛠 Create Edge App
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ env.SCREENLY_API_TOKEN }}
-          cli_commands: edge-app create --name="${{ env.APP_NAME }}" --in-place --path="${{ env.APP_PATH }}"
-
-      - name: 🚀 Deploy Edge App
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ env.SCREENLY_API_TOKEN }}
-          cli_commands: edge-app deploy --path="${{ env.APP_PATH }}"
-
-      - name: 📋 Log screenly.yml
-        run: |
-          cat ${{ env.APP_PATH }}/${{ env.MANIFEST_FILE_NAME }}
-
-      - name: 📄 Create Instance
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ env.SCREENLY_API_TOKEN }}
-          cli_commands: edge-app instance create --path="${{ env.APP_PATH }}" --name="${{ inputs.edge_app_title }}"
-
-      - name: 🔄 Update Instance
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ env.SCREENLY_API_TOKEN }}
-          cli_commands: edge-app instance update --path="${{ env.APP_PATH }}"
-
-      - name: 📋 Log instance.yml
-        run: |
-          cat ${{ env.APP_PATH }}/instance.yml
+          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN }}
+          edge_app_name: ${{ inputs.edge_app_name }}
+          edge_app_title: ${{ inputs.edge_app_title }}
+          environment: ${{ inputs.environment }}
+          path: edge-apps/${{ inputs.edge_app_name }}

--- a/.github/workflows/update-edge-app.yml
+++ b/.github/workflows/update-edge-app.yml
@@ -22,21 +22,6 @@ on:
         default: false
         type: boolean
 
-      build_system:
-        description: "Build system for the Edge App"
-        required: true
-        default: "vanilla"
-        type: choice
-        options:
-          - vanilla
-          - bun
-
-      deploy_from_dist:
-        description: "Deploy from the dist folder. If unchecked, deploy from app's root folder."
-        required: true
-        default: true
-        type: boolean
-
 run-name: Updating ${{ inputs.edge_app_name }} in ${{ inputs.environment }}
 
 jobs:
@@ -45,40 +30,16 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
     environment: ${{ inputs.environment }}
-    env:
-      API_BASE_URL: ${{ inputs.environment == 'stage' && 'https://api.screenlyappstage.com' || 'https://api.screenlyapp.com' }}
-      APP_NAME: ${{ inputs.edge_app_name }}
-      APP_PATH: edge-apps/${{ inputs.edge_app_name }}
-      SCREENLY_API_TOKEN: ${{ secrets.SCREENLY_API_TOKEN }}
-      MANIFEST_FILE_NAME: ${{ inputs.environment == 'stage' && 'screenly_qc.yml' || 'screenly.yml' }}
 
     steps:
-      - name: ⬇️  Checkout master branch
+      - name: ⬇️ Checkout master branch
         uses: actions/checkout@v6
         with:
           ref: master
 
-      - name: 🛠 Install Bun (React/Vue only)
-        if: ${{ inputs.build_system == 'bun' }}
-        uses: oven-sh/setup-bun@v2
+      - uses: Screenly/edge-apps-actions/update@feat/add-path-input
         with:
-          bun-version: 1.2.2
-
-      - name: 🛠 Setup and Build React/Vue App
-        if: ${{ inputs.build_system == 'bun' }}
-        working-directory: ${{ env.APP_PATH }}
-        run: |
-          bun install
-          bun run build
-
-      - name: 🔄 Modify APP_PATH based on app type
-        run: |
-          if [ "${{ inputs.build_system }}" = "bun" ] && [ "${{ inputs.deploy_from_dist }}" = "true" ]; then
-            echo "APP_PATH=${{ env.APP_PATH }}/dist" >> "$GITHUB_ENV"
-          fi
-
-      - name: 🚀 Deploy Edge App
-        uses: screenly/cli@master
-        with:
-          screenly_api_token: ${{ env.SCREENLY_API_TOKEN }}
-          cli_commands: edge-app deploy --path="${{ env.APP_PATH }}" --delete-missing-settings=${{ inputs.delete_missing_settings }}
+          screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN }}
+          environment: ${{ inputs.environment }}
+          delete_missing_settings: ${{ inputs.delete_missing_settings }}
+          path: edge-apps/${{ inputs.edge_app_name }}

--- a/.github/workflows/update-edge-app.yml
+++ b/.github/workflows/update-edge-app.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           ref: master
 
-      - uses: Screenly/edge-apps-actions/update@feat/add-path-input
+      - uses: Screenly/edge-apps-actions/update@v1
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN }}
           environment: ${{ inputs.environment }}


### PR DESCRIPTION
### **User description**
## Summary

- Replace inline build/deploy steps in `initialize-app.yml` and `update-edge-app.yml` with `Screenly/edge-apps-actions`
- Drop explicit `build_system` and `deploy_from_dist` inputs — the actions auto-detect via `package.json`
- Pass `path: edge-apps/<app_name>` to support the monorepo layout

## Depends on

Screenly/edge-apps-actions#7 — must be merged and the `v1` tag moved before this workflow reference is updated from `@feat/add-path-input` to `@v1`.


___

### **PR Type**
Enhancement


___

### **Description**
- Replace initialization workflow with reusable action

- Replace update workflow with reusable action

- Pass monorepo `path` and environment inputs

- Pin shared edge-app actions to `v1`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  init["initialize-app.yml"]
  upd["update-edge-app.yml"]
  shared["Screenly/edge-apps-actions@v1"]
  path["Monorepo path input"]
  config["Shared token and environment inputs"]
  init -- "delegates initialize" --> shared
  upd -- "delegates update" --> shared
  shared -- "targets app subdirectory" --> path
  shared -- "receives workflow context" --> config
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>initialize-app.yml</strong><dd><code>Switch initialization to reusable shared action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/initialize-app.yml

<ul><li>Use <code>Screenly/edge-apps-actions/initialize@v1</code><br> <li> Pass <code>screenly_api_token</code>, app name, title, and environment<br> <li> Add <code>path</code> as <code>edge-apps/${{ inputs.edge_app_name }}</code><br> <li> Simplify workflow to shared initialization entrypoint</ul>


</details>


  </td>
  <td><a href="https://github.com/Screenly/Playground/pull/801/files#diff-aa6053abeb1aada4d6abc59efda978151637f1b39550d94070a49f5cd2ca5ec8">+6/-70</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>update-edge-app.yml</strong><dd><code>Switch update flow to reusable action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/update-edge-app.yml

<ul><li>Use <code>Screenly/edge-apps-actions/update@v1</code><br> <li> Pass <code>screenly_api_token</code>, <code>environment</code>, and deletion flag<br> <li> Add monorepo-aware <code>path</code> for the target app<br> <li> Standardize update flow through shared action</ul>


</details>


  </td>
  <td><a href="https://github.com/Screenly/Playground/pull/801/files#diff-be5c3873aea4becaeaefed99b6b4c0cc04e182a1d7c84aac62541ec5e0be811b">+6/-45</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

