### PR TITLE
ci: add stale PR workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+name: Mark Stale PRs
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10.3.0
+        with:
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
+          stale-pr-label: 'stale'
+          stale-pr-message: >
+            This PR has been inactive for 30 days and has been marked as stale.
+            It will be closed in 7 days if there is no further activity.
+            Please update the PR or leave a comment if it is still being worked on.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,14 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  DAYS_BEFORE_STALE: 60
+  DAYS_BEFORE_CLOSE: 7
+
 jobs:
   stale:
     runs-on: ubuntu-latest
@@ -13,10 +21,10 @@ jobs:
         with:
           days-before-issue-stale: -1
           days-before-issue-close: -1
-          days-before-pr-stale: 30
-          days-before-pr-close: 7
+          days-before-pr-stale: ${{ env.DAYS_BEFORE_STALE }}
+          days-before-pr-close: ${{ env.DAYS_BEFORE_CLOSE }}
           stale-pr-label: 'stale'
           stale-pr-message: >
-            This PR has been inactive for 30 days and has been marked as stale.
-            It will be closed in 7 days if there is no further activity.
+            This PR has been inactive for ${{ env.DAYS_BEFORE_STALE }} days and has been marked as stale.
+            It will be closed in ${{ env.DAYS_BEFORE_CLOSE }} days if there is no further activity.
             Please update the PR or leave a comment if it is still being worked on.


### PR DESCRIPTION
### **User description**
## Summary

- Adds a daily GitHub Actions workflow to manage stale PRs
- Marks PRs as stale after 60 days of inactivity
- Closes stale PRs 7 days after being marked stale
- Issues are excluded from stale checks
- Adds explicit `contents: read` and `pull-requests: write` permissions
- Extracts thresholds into env vars to keep the stale message in sync


___

### **PR Type**
Enhancement


___

### **Description**
- Adds scheduled stale PR cleanup

- Marks inactive PRs after 60 days

- Closes stale PRs after 7 days

- Excludes issues from stale processing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  schedule["Daily schedule or manual dispatch"]
  action["actions/stale workflow"]
  stale["Mark inactive PRs stale"]
  close["Close still-inactive stale PRs"]
  schedule -- "triggers" --> action
  action -- "after 60 days" --> stale
  stale -- "after 7 more days" --> close
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stale.yml</strong><dd><code>Add stale pull request workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/stale.yml

<ul><li>Adds a <code>Mark Stale PRs</code> GitHub Actions workflow.<br> <li> Runs daily via cron and supports <code>workflow_dispatch</code>.<br> <li> Configures <code>actions/stale@v10.3.0</code> for PR-only stale handling.<br> <li> Uses env vars for stale and close thresholds.</ul>


</details>


  </td>
  <td><a href="https://github.com/Screenly/Playground/pull/808/files#diff-b5e0854ed0838024d5cc25b4e030922e34648b9ea8c432807e35495fb805b894">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

