### PR TITLE
feat(injectors): add Airtable cookie consent closing injector

### DIFF
--- a/javascript-injectors/README.md
+++ b/javascript-injectors/README.md
@@ -241,3 +241,10 @@ $ screenly asset inject-js "$ASSET_ID" "$JAVASCRIPT_URL"
 
 - Download [dynatrace-login-via-credentials.js](https://github.com/Screenly/Playground/tree/master/javascript-injectors/examples/dynatrace-login-via-credentials.js) and modify it with your credentials.
 - Run `screenly asset inject-js "$ASSET_ID" /path/to/script.js` to add the JavaScript
+
+## Airtable cookies consent closing
+
+```bash
+$ export JAVASCRIPT_URL='https://raw.githubusercontent.com/Screenly/Playground/master/javascript-injectors/examples/airtable-cookies-consent-closing.js'
+$ screenly asset inject-js "$ASSET_ID" "$JAVASCRIPT_URL"
+```

--- a/javascript-injectors/examples/airtable-cookies-consent-closing.js
+++ b/javascript-injectors/examples/airtable-cookies-consent-closing.js
@@ -1,0 +1,5 @@
+/* Hides the OneTrust cookie consent banner via CSS rather than clicking,
+ * since the banner loads asynchronously and click-based approaches are unreliable. */
+const style = document.createElement('style');
+style.textContent = '#onetrust-consent-sdk { display: none !important; }';
+document.head.appendChild(style);

--- a/javascript-injectors/examples/airtable-cookies-consent-closing.js
+++ b/javascript-injectors/examples/airtable-cookies-consent-closing.js
@@ -1,10 +1,10 @@
 (function () {
   /* Hides the OneTrust cookie consent banner via CSS rather than clicking,
    * since the banner loads asynchronously and click-based approaches are unreliable. */
-  if (document.getElementById('screenly-airtable-consent-hide')) return;
+  if (document.getElementById('screenly-airtable-consent-hide')) return
 
-  const style = document.createElement('style');
-  style.id = 'screenly-airtable-consent-hide';
-  style.textContent = '#onetrust-consent-sdk { display: none !important; }';
-  (document.head || document.documentElement).appendChild(style);
+  const style = document.createElement('style')
+  style.id = 'screenly-airtable-consent-hide'
+  style.textContent = '#onetrust-consent-sdk { display: none !important; }'
+  ;(document.head || document.documentElement).appendChild(style)
 })()

--- a/javascript-injectors/examples/airtable-cookies-consent-closing.js
+++ b/javascript-injectors/examples/airtable-cookies-consent-closing.js
@@ -1,5 +1,10 @@
-/* Hides the OneTrust cookie consent banner via CSS rather than clicking,
- * since the banner loads asynchronously and click-based approaches are unreliable. */
-const style = document.createElement('style');
-style.textContent = '#onetrust-consent-sdk { display: none !important; }';
-document.head.appendChild(style);
+(function () {
+  /* Hides the OneTrust cookie consent banner via CSS rather than clicking,
+   * since the banner loads asynchronously and click-based approaches are unreliable. */
+  if (document.getElementById('screenly-airtable-consent-hide')) return;
+
+  const style = document.createElement('style');
+  style.id = 'screenly-airtable-consent-hide';
+  style.textContent = '#onetrust-consent-sdk { display: none !important; }';
+  (document.head || document.documentElement).appendChild(style);
+})()


### PR DESCRIPTION
### **User description**
## Summary

- Adds a JavaScript injector for Airtable that hides the OneTrust cookie consent banner
- Uses CSS injection (`display: none`) targeting `#onetrust-consent-sdk` for reliability, since the banner loads asynchronously


___

### **PR Type**
Enhancement


___

### **Description**
- Add Airtable cookie consent injector

- Hide OneTrust banner using CSS


___

### Diagram Walkthrough


```mermaid
flowchart LR
  injector["Airtable injector"] 
  style["Create style element"]
  css["Hide OneTrust banner"]
  head["Append to document head"]
  injector -- "creates" --> style
  style -- "contains CSS" --> css
  style -- "injects into" --> head
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>airtable-cookies-consent-closing.js</strong><dd><code>Airtable OneTrust consent banner CSS hider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript-injectors/examples/airtable-cookies-consent-closing.js

<ul><li>Adds a new Airtable JavaScript injector example.<br> <li> Creates a <code>style</code> element at runtime.<br> <li> Hides <code>#onetrust-consent-sdk</code> with <code>display: none !important</code>.<br> <li> Appends the CSS to <code>document.head</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/Screenly/Playground/pull/847/files#diff-1bd41ca4a29f1b564473b63723684e9de95795ec258136bcb49ba1ffcd614653">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

