### PR TITLE
chore: remove bun ecosystem from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,16 +3,6 @@ version: 2
 # See: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#directories-or-directory--
 
 updates:
-  - package-ecosystem: 'bun'
-    directories:
-      - 'edge-apps/*'
-    schedule:
-      interval: 'monthly'
-    groups:
-      bun:
-        patterns:
-          - '*'
-
   - package-ecosystem: 'pip'
     directory: '/edge-apps/queue-management-system/server'
     schedule:


### PR DESCRIPTION
## Summary
- Removes the `bun` package-ecosystem entry from `.github/dependabot.yml` now that all Bun-based Edge Apps have been migrated to separate repositories