### PR TITLE
docs(edge-apps): add Sentry error reporting guidance

### DIFF
--- a/.claude/skills/create-an-edge-app/SKILL.md
+++ b/.claude/skills/create-an-edge-app/SKILL.md
@@ -37,7 +37,7 @@ Both paths feed the same `getCredentials()` — the Edge App code does not chang
 
 ## Error Reporting (Sentry)
 
-Every Edge App should support optional Sentry error reporting, gated behind a `sentry_dsn` setting that no-ops when unset.
+New Edge Apps should support optional Sentry error reporting, gated behind a `sentry_dsn` setting that no-ops when unset.
 
 - Add a `sentry_dsn` setting to `screenly.yml`/`screenly_qc.yml` as a global secret that no-ops when unset:
   ```yaml
@@ -51,7 +51,7 @@ Every Edge App should support optional Sentry error reporting, gated behind a `s
         schema_version: 1
         properties:
           advanced: true
-          help_text: Sentry DSN for reporting <app-specific> errors. Leave empty to disable.
+          help_text: Sentry DSN for reporting errors. Leave empty to disable.
           type: string
   ```
 - Call `setupSentry` from `@screenly/edge-apps/utils` once, near the top of `src/main.ts`, before other startup logic, passing the app name and any settings or metadata useful as context:

--- a/.claude/skills/create-an-edge-app/SKILL.md
+++ b/.claude/skills/create-an-edge-app/SKILL.md
@@ -54,9 +54,9 @@ Every Edge App should support optional Sentry error reporting, gated behind a `s
           help_text: Sentry DSN for reporting <app-specific> errors. Leave empty to disable.
           type: string
   ```
-- Call `setupSentry` from `@screenly/edge-apps/utils` once, near the top of `src/main.ts`, before other startup logic, passing the app name and any settings useful as context:
+- Call `setupSentry` from `@screenly/edge-apps/utils` once, near the top of `src/main.ts`, before other startup logic, passing the app name and any settings or metadata useful as context:
   ```ts
-  setupSentry('app-name', { 'app-name': { contentId: screenly.settings.content_id } })
+  setupSentry('app-name', { 'app-name': { screenName: screenly.metadata.screen_name } })
   ```
 - Report failures with `reportError(error, { source: 'short-context' })` from `@screenly/edge-apps/utils` at meaningful failure points (credential refresh, content load, API errors) — not for expected or already-handled states.
 - Dedupe repeated consecutive failures of the same kind (e.g. only report the first of a run of identical background-refresh errors) so retry loops don't spam Sentry.

--- a/.claude/skills/create-an-edge-app/SKILL.md
+++ b/.claude/skills/create-an-edge-app/SKILL.md
@@ -39,9 +39,26 @@ Both paths feed the same `getCredentials()` — the Edge App code does not chang
 
 Every Edge App should support optional Sentry error reporting, gated behind a `sentry_dsn` setting that no-ops when unset.
 
-- Add a `sentry_dsn` setting to `screenly.yml`/`screenly_qc.yml`: `type: secret`, `optional: true`, `is_global: true` (shared across app instances rather than configured per-instance). Use the structured `help_text` format with `advanced: true` and a short description of what's being reported.
-- Call `setupSentry('<app-name>', { <app-name>: { ...relevant settings for context... } })` from `@screenly/edge-apps/utils` once, near the top of `main.ts`, before other startup logic.
-- Report failures with `reportError(error, { source: '<short-context>' })` from `@screenly/edge-apps/utils` at meaningful failure points (credential refresh, content load, API errors) — not for expected or already-handled states.
+- Add a `sentry_dsn` setting to `screenly.yml`/`screenly_qc.yml` as a global secret that no-ops when unset:
+  ```yaml
+  settings:
+    sentry_dsn:
+      type: secret
+      title: Sentry DSN
+      optional: true
+      is_global: true
+      help_text:
+        schema_version: 1
+        properties:
+          advanced: true
+          help_text: Sentry DSN for reporting <app-specific> errors. Leave empty to disable.
+          type: string
+  ```
+- Call `setupSentry` from `@screenly/edge-apps/utils` once, near the top of `src/main.ts`, before other startup logic, passing the app name and any settings useful as context:
+  ```ts
+  setupSentry('app-name', { 'app-name': { contentId: screenly.settings.content_id } })
+  ```
+- Report failures with `reportError(error, { source: 'short-context' })` from `@screenly/edge-apps/utils` at meaningful failure points (credential refresh, content load, API errors) — not for expected or already-handled states.
 - Dedupe repeated consecutive failures of the same kind (e.g. only report the first of a run of identical background-refresh errors) so retry loops don't spam Sentry.
 - Requires `@screenly/edge-apps` `^1.1.0` or later.
 - See [Screenly/salesforce-app](https://github.com/Screenly/salesforce-app) (`src/main.ts`, `src/credentials.ts`) and [Screenly/powerbi-app](https://github.com/Screenly/powerbi-app) (`src/main.ts`, `src/services.ts`) for reference implementations.

--- a/.claude/skills/create-an-edge-app/SKILL.md
+++ b/.claude/skills/create-an-edge-app/SKILL.md
@@ -35,6 +35,17 @@ To develop locally (real credentials aren't present), set up a **super simple** 
 
 Both paths feed the same `getCredentials()` — the Edge App code does not change between them.
 
+## Error Reporting (Sentry)
+
+Every Edge App should support optional Sentry error reporting, gated behind a `sentry_dsn` setting that no-ops when unset.
+
+- Add a `sentry_dsn` setting to `screenly.yml`/`screenly_qc.yml`: `type: secret`, `optional: true`, `is_global: true` (shared across app instances rather than configured per-instance). Use the structured `help_text` format with `advanced: true` and a short description of what's being reported.
+- Call `setupSentry('<app-name>', { <app-name>: { ...relevant settings for context... } })` from `@screenly/edge-apps/utils` once, near the top of `main.ts`, before other startup logic.
+- Report failures with `reportError(error, { source: '<short-context>' })` from `@screenly/edge-apps/utils` at meaningful failure points (credential refresh, content load, API errors) — not for expected or already-handled states.
+- Dedupe repeated consecutive failures of the same kind (e.g. only report the first of a run of identical background-refresh errors) so retry loops don't spam Sentry.
+- Requires `@screenly/edge-apps` `^1.1.0` or later.
+- See [Screenly/salesforce-app](https://github.com/Screenly/salesforce-app) (`src/main.ts`, `src/credentials.ts`) and [Screenly/powerbi-app](https://github.com/Screenly/powerbi-app) (`src/main.ts`, `src/services.ts`) for reference implementations.
+
 ## Testing
 
 - Write tests before the feature, then make them pass. Every app ships an `e2e/` directory (Playwright); add cases there for the behavior you build.


### PR DESCRIPTION
## Summary
- Add a new "Error Reporting (Sentry)" section to the `create-an-edge-app` skill documenting the `sentry_dsn` setting pattern (`type: secret`, `optional: true`, `is_global: true`).
- Document `setupSentry`/`reportError` usage from `@screenly/edge-apps/utils`.
- Reference [Screenly/salesforce-app](https://github.com/Screenly/salesforce-app) and [Screenly/powerbi-app](https://github.com/Screenly/powerbi-app) as implementation examples.

## Test plan
- [x] Docs-only change; no code to test.