### PR TITLE
docs: recommend the create-scaffold generator for new Edge Apps

### DIFF
--- a/.claude/skills/create-an-edge-app/SKILL.md
+++ b/.claude/skills/create-an-edge-app/SKILL.md
@@ -8,8 +8,13 @@ description: Use when scaffolding a new Screenly Edge App — covers the templat
 ## When Creating an Edge App
 
 - If you're one of the maintainers of this repository, it's encouraged to create the new Edge App in its own standalone GitHub repo under the Screenly org, rather than inside this monorepo's `edge-apps/` directory.
-- Scaffold the new Edge App by starting from one of the apps in the [Reference Apps](#reference-apps) section below — pick the closest match in complexity and adapt it, following the `kebab-case` naming convention for the app name.
-- After scaffolding, add an `id` field to `screenly.yml` and `screenly_qc.yml` before running `bun run dev`.
+- It's recommended to scaffold the new Edge App first with the `@screenly/edge-apps` create-scaffold generator, following the `kebab-case` naming convention for the app name:
+  ```bash
+  bunx @screenly/edge-apps create <app-name>
+  ```
+  This produces a minimal, working app — manifest, `index.html`, `src/main.ts`, and the standard dev/build/lint/test/deploy scripts — already wired up to the library's conventions. Requires `@screenly/edge-apps` `^1.2.0` or later.
+- The generator only produces a basic app. Still check the closest match in the [Reference Apps](#reference-apps) section below and adapt from there for anything past that starting point — integrations/auth, Sentry error reporting, non-trivial settings, or a closer starting point for a complex UI. Note that the generator does not create `screenly_qc.yml` (an internal-only staging manifest) — copy one over from a reference app if your app needs one, and keep both manifests in sync.
+- After scaffolding, register the app to populate a real `id` in `screenly.yml` (and `screenly_qc.yml`, if added): `screenly edge-app create --name <app-name> --in-place`.
 - **Verify it boots** before building features: run `bun run dev`, `bun run lint`, and the tests. A scaffold that doesn't start is the first thing to fix.
 - **Consult Figma designs** before starting implementation.
   - Ensure the [Figma MCP server](https://mcp.figma.com/mcp) is set up in Claude Code.

--- a/.claude/skills/create-an-edge-app/SKILL.md
+++ b/.claude/skills/create-an-edge-app/SKILL.md
@@ -12,9 +12,8 @@ description: Use when scaffolding a new Screenly Edge App — covers the templat
   ```bash
   bunx @screenly/edge-apps create <app-name>
   ```
-  This produces a minimal, working app — manifest, `index.html`, `src/main.ts`, and the standard dev/build/lint/test/deploy scripts — already wired up to the library's conventions. Requires `@screenly/edge-apps` `^1.2.0` or later.
+  This produces a minimal, working app — manifest, `index.html`, `src/main.ts`, and the standard dev/build/lint/test/deploy scripts — already wired up to the library's conventions. Requires `@screenly/edge-apps` `>=1.2.0`.
 - The generator only produces a basic app. Still check the closest match in the [Reference Apps](#reference-apps) section below and adapt from there for anything past that starting point — integrations/auth, Sentry error reporting, non-trivial settings, or a closer starting point for a complex UI. Note that the generator does not create `screenly_qc.yml` (an internal-only staging manifest) — copy one over from a reference app if your app needs one, and keep both manifests in sync.
-- After scaffolding, register the app to populate a real `id` in `screenly.yml` (and `screenly_qc.yml`, if added): `screenly edge-app create --name <app-name> --in-place`.
 - **Verify it boots** before building features: run `bun run dev`, `bun run lint`, and the tests. A scaffold that doesn't start is the first thing to fix.
 - **Consult Figma designs** before starting implementation.
   - Ensure the [Figma MCP server](https://mcp.figma.com/mcp) is set up in Claude Code.

--- a/.claude/skills/create-an-edge-app/SKILL.md
+++ b/.claude/skills/create-an-edge-app/SKILL.md
@@ -13,6 +13,10 @@ description: Use when scaffolding a new Screenly Edge App — covers the templat
   bunx @screenly/edge-apps create <app-name>
   ```
   This produces a minimal, working app — manifest, `index.html`, `src/main.ts`, and the standard dev/build/lint/test/deploy scripts — already wired up to the library's conventions. Requires `@screenly/edge-apps` `>=1.2.0`.
+- After scaffolding — and before or alongside making further code changes — add and initialize the [`edge-apps-claude-config`](https://github.com/Screenly/edge-apps-claude-config) submodule for Claude AI configuration:
+  ```bash
+  git submodule add https://github.com/Screenly/edge-apps-claude-config .claude
+  ```
 - The generator only produces a basic app. Still check the closest match in the [Reference Apps](#reference-apps) section below and adapt from there for anything past that starting point — integrations/auth, Sentry error reporting, non-trivial settings, or a closer starting point for a complex UI. Note that the generator does not create `screenly_qc.yml` (an internal-only staging manifest) — copy one over from a reference app if your app needs one, and keep both manifests in sync.
 - **Verify it boots** before building features: run `bun run dev`, `bun run lint`, and the tests. A scaffold that doesn't start is the first thing to fix.
 - **Consult Figma designs** before starting implementation.

--- a/.claude/skills/create-an-edge-app/SKILL.md
+++ b/.claude/skills/create-an-edge-app/SKILL.md
@@ -13,10 +13,11 @@ description: Use when scaffolding a new Screenly Edge App — covers the templat
   bunx @screenly/edge-apps create <app-name>
   ```
   This produces a minimal, working app — manifest, `index.html`, `src/main.ts`, and the standard dev/build/lint/test/deploy scripts — already wired up to the library's conventions. Requires `@screenly/edge-apps` `>=1.2.0`.
-- After scaffolding — and before or alongside making further code changes — add and initialize the [`edge-apps-claude-config`](https://github.com/Screenly/edge-apps-claude-config) submodule for Claude AI configuration:
+- If the new Edge App lives in its own standalone repo (not inside this monorepo, which already has its own `.claude/`), add and initialize the [`edge-apps-claude-config`](https://github.com/Screenly/edge-apps-claude-config) submodule for Claude AI configuration right after scaffolding, before or alongside making further code changes:
   ```bash
   git submodule add https://github.com/Screenly/edge-apps-claude-config .claude
   ```
+  Teammates cloning the repo afterward need to populate it: `git submodule update --init` (or clone with `--recurse-submodules`).
 - The generator only produces a basic app. Still check the closest match in the [Reference Apps](#reference-apps) section below and adapt from there for anything past that starting point — integrations/auth, Sentry error reporting, non-trivial settings, or a closer starting point for a complex UI. Note that the generator does not create `screenly_qc.yml` (an internal-only staging manifest) — copy one over from a reference app if your app needs one, and keep both manifests in sync.
 - **Verify it boots** before building features: run `bun run dev`, `bun run lint`, and the tests. A scaffold that doesn't start is the first thing to fix.
 - **Consult Figma designs** before starting implementation.


### PR DESCRIPTION
## Summary
- Recommend scaffolding new Edge Apps first with `bunx @screenly/edge-apps create <app-name>` (added in `@screenly/edge-apps` 1.2.0) instead of starting from a reference app.
- Still point to the Reference Apps section for anything past the generator's basic output — integrations/auth, Sentry, `screenly_qc.yml`, complex UI — since the generator only produces a minimal app.
- Update the id-registration step to match the generator's actual behavior (no blank `id` placeholder, no `screenly_qc.yml` by default).