### PR TITLE
fix(js-injector): hide Transcend cookie banner on Airtable

### DIFF
--- a/javascript-injectors/examples/airtable-cookies-consent-closing.js
+++ b/javascript-injectors/examples/airtable-cookies-consent-closing.js
@@ -1,10 +1,11 @@
 (function () {
-  /* Hides the OneTrust cookie consent banner via CSS rather than clicking,
-   * since the banner loads asynchronously and click-based approaches are unreliable. */
+  /* Hides the cookie consent banner via CSS since it loads asynchronously.
+   * Covers both OneTrust and Transcend, as Airtable has switched before. */
   if (document.getElementById('screenly-airtable-consent-hide')) return
 
   const style = document.createElement('style')
   style.id = 'screenly-airtable-consent-hide'
-  style.textContent = '#onetrust-consent-sdk { display: none !important; }'
+  style.textContent =
+    '#onetrust-consent-sdk, #transcend-shadow-root { display: none !important; }'
   ;(document.head || document.documentElement).appendChild(style)
 })()


### PR DESCRIPTION
## Summary
- Airtable switched consent platforms from OneTrust to Transcend
- Hide the Transcend shadow host in addition to OneTrust's, since it now renders the consent UI

## Test plan
- [x] Verified in browser DevTools that the injected CSS hides `#transcend-shadow-root`
- [x] Verify via `screenly asset inject-js` against a live Anywhere screen